### PR TITLE
New authentication endpoint controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ SINGPASS_PRIVATE_JWKS=
 # Default Routes
 SINGPASS_USE_DEFAULT_ROUTES=true
 SINGPASS_JWKS_URL=/sp/jwks
+SINGPASS_AUTHENTICATION_URL=/sp/login
 SINGPASS_CALLBACK_URL=/sp/callback
 
 # Default Listener
@@ -51,20 +52,23 @@ php artisan vendor:publish --provider="Accredifysg\SingPassLogin\SingPassLoginSe
 ## Usage and Customisations
 
 ### Controllers and Routes
-There are two default controllers that handle the login process
+There are three default controllers that handle the login process
 
 `GetJwksEndpointController` exposes your application's JWKS endpoint to be registered with SingPass. 
 The default route for this controller is `/sp/jwks`
+
+`GetAuthenticationEndpointController` provides the authentication endpoint to redirect the client's browser to.
+The default route for this controller is `/sp/login`
 
 `PostSingPassCallbackController` handles the callback from SingPass, and kick-starts the login process.
 The default route for this controller is `/sp/callback`
 
 If you prefer to set your own routes you can set `SINGPASS_USE_DEFAULT_ROUTES` to `false`, 
-then edit `SINGPASS_JWKS_URL` and `SINGPASS_CALLBACK_URL` in
+then edit `SINGPASS_JWKS_URL`, `SINGPASS_CALLBACK_URL`, and `SINGPASS_AUTHENTICATION_URL` in
 your `.env` file and map your own routes. 
 
 If you prefer to write your own controllers you can define them in the config file
-`SingPass-Login.php` as `get_jwks_endpoint_controller` and `post_singpass_callback_controller`
+`singpass-login.php` as `get_jwks_endpoint_controller`, `post_singpass_callback_controller` and `get_authentication_endpoint_controller`
 
 ### Listener
 If you published the default listener, you should edit it and map your user retrieval via NRIC accordingly.
@@ -87,7 +91,7 @@ public function handle(SingPassSuccessfulLoginEvent $event): RedirectResponse
 ```
 
 If you prefer to write your own, you can set `SINGPASS_USE_DEFAULT_LISTENER` to `false` in
-your `.env` and replace `listener_class` in the config file `SingPass-Login.php`
+your `.env` and replace `listener_class` in the config file `singpass-login.php`
 
 ## Exceptions
 ```php

--- a/config/singpass-login.php
+++ b/config/singpass-login.php
@@ -1,5 +1,6 @@
 <?php
 
+use Accredifysg\SingPassLogin\Http\Controllers\GetAuthenticationEndpointController;
 use Accredifysg\SingPassLogin\Http\Controllers\GetJwksEndpointController;
 use Accredifysg\SingPassLogin\Http\Controllers\PostSingPassCallbackController;
 use Accredifysg\SingPassLogin\Listeners\SingPassSuccessfulLoginListener;
@@ -16,10 +17,12 @@ return [
     // Default routes
     'enable_default_singpass_routes' => env('SINGPASS_USE_DEFAULT_ROUTES', true),
     'get_jwks_endpoint_url' => env('SINGPASS_JWKS_URL', '/sp/jwks'),
+    'get_authentication_endpoint_url' => env('SINGPASS_AUTHENTICATION_URL', '/sp/login'),
     'post_singpass_callback_url' => env('SINGPASS_CALLBACK_URL', '/sp/callback'),
 
     // Default controllers
     'get_jwks_endpoint_controller' => GetJwksEndpointController::class,
+    'get_authentication_endpoint_controller' => GetAuthenticationEndpointController::class,
     'post_singpass_callback_controller' => PostSingPassCallbackController::class,
 
     // Debug mode

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,3 +11,8 @@ Route::get(
     config('singpass-login.get_jwks_endpoint_url'),
     config('singpass-login.get_jwks_endpoint_controller')
 )->name('singpass.jwks');
+
+Route::get(
+    config('singpass-login.get_authentication_endpoint_url'),
+    config('singpass-login.get_authentication_endpoint_controller')
+)->name('singpass.login');

--- a/src/Http/Controllers/GetAuthenticationEndpointController.php
+++ b/src/Http/Controllers/GetAuthenticationEndpointController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Accredifysg\SingPassLogin\Http\Controllers;
+
+use Accredifysg\SingPassLogin\Services\OpenIdDiscoveryService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class GetAuthenticationEndpointController extends Controller
+{
+    /**
+     * Returns the authentication endpoint for the browser to consume
+     */
+    public function __invoke(Request $request): JsonResponse
+    {
+        (new OpenIdDiscoveryService)->cacheOpenIdDiscovery();
+        $redirectUri = config('singpass-login.redirect_uri');
+        $responseType = 'code';
+        $state = 'LOGIN-'.Str::uuid();
+        $scope = 'openid';
+        $singPassAuthenticationEndpoint = Cache::get('openId')->authorization_endpoint;
+        $clientID = config('singpass-login.client_id');
+        $nonce = Str::uuid();
+
+        $singPassQuery = "redirect_uri=$redirectUri&response_type=$responseType&state=$state&scope=$scope&client_id=$clientID&nonce=$nonce";
+        $redirectUrl = "{$singPassAuthenticationEndpoint}?{$singPassQuery}";
+
+        return response()->json(['redirect_url' => $redirectUrl]);
+    }
+}

--- a/src/Http/Controllers/GetJwksEndpointController.php
+++ b/src/Http/Controllers/GetJwksEndpointController.php
@@ -15,7 +15,7 @@ class GetJwksEndpointController extends Controller
      */
     public function __invoke(Request $request): JsonResponse
     {
-        $jwks = config('services.singpass-login.jwks');
+        $jwks = config('singpass-login.jwks');
 
         if ($jwks !== null) {
 

--- a/src/Services/GetSingPassTokenService.php
+++ b/src/Services/GetSingPassTokenService.php
@@ -18,8 +18,8 @@ final class GetSingPassTokenService implements GetSingPassTokenServiceInterface
      */
     public function getToken(string $code): string
     {
-        $clientId = config('services.singpass-login.clientId');
-        $redirectUrl = config('services.singpass-login.redirectionUrl');
+        $clientId = config('singpass-login.clientId');
+        $redirectUrl = config('singpass-login.redirectionUrl');
         $grantType = 'authorization_code';
         $clientAssertionType = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
 

--- a/src/Services/OpenIdDiscoveryService.php
+++ b/src/Services/OpenIdDiscoveryService.php
@@ -18,7 +18,7 @@ final class OpenIdDiscoveryService implements OpenIdDiscoveryServiceInterface
     public function cacheOpenIdDiscovery(): void
     {
         Cache::remember('openId', now()->addHour(), static function () {
-            $response = Http::get(config('services.singpass-login.discovery_endpoint'));
+            $response = Http::get(config('singpass-login.discovery_endpoint'));
 
             if ($response->failed()) {
                 throw new OpenIdDiscoveryException($response->status());

--- a/src/Services/SingPassJwtService.php
+++ b/src/Services/SingPassJwtService.php
@@ -42,7 +42,7 @@ final class SingPassJwtService implements SingPassJwtServiceInterface
      */
     public static function getSigningJwk(): JWK|JWKSet
     {
-        $jwks = config('services.singpass-login.private_jwks');
+        $jwks = config('singpass-login.private_jwks');
 
         if ($jwks === null) {
             throw new JwksInvalidException(500, 'Private JWKS not set.');
@@ -55,7 +55,7 @@ final class SingPassJwtService implements SingPassJwtServiceInterface
         }
 
         try {
-            $signingKey = $jwkSets->get(config('services.singpass-login.signing_kid'));
+            $signingKey = $jwkSets->get(config('singpass-login.signing_kid'));
         } catch (Exception) {
             throw new JwksInvalidException(500, 'Signing key not found.');
         }
@@ -75,9 +75,9 @@ final class SingPassJwtService implements SingPassJwtServiceInterface
         $jwsBuilder = new JWSBuilder($algorithmManager);
 
         $payload = json_encode([
-            'sub' => config('services.singpass-login.clientId'),
+            'sub' => config('singpass-login.clientId'),
             'aud' => Cache::get('openId')->issuer,
-            'iss' => config('services.singpass-login.clientId'),
+            'iss' => config('singpass-login.clientId'),
             'iat' => time(),
             'exp' => time() + 119,
         ]);
@@ -88,7 +88,7 @@ final class SingPassJwtService implements SingPassJwtServiceInterface
                 ->addSignature($jwk, [
                     'typ' => 'JWT',
                     'alg' => 'ES512',
-                    'kid' => config('services.singpass-login.signingKid'),
+                    'kid' => config('singpass-login.signingKid'),
                 ])->build();
         } catch (Exception) {
             throw new JwksInvalidException(500, 'JWKS JSON Invalid.');
@@ -126,7 +126,7 @@ final class SingPassJwtService implements SingPassJwtServiceInterface
 
         try {
             $kid = $jwe->getSharedProtectedHeaderParameter('kid');
-            $keySet = JWKFactory::createFromJsonObject(config('services.singpass-login.private_jwks'));
+            $keySet = JWKFactory::createFromJsonObject(config('singpass-login.private_jwks'));
             $key = $keySet->get($kid);
         } catch (InvalidArgumentException) {
             throw new JweDecryptionFailedException(500, 'KID specified not found in JWKS.');
@@ -208,14 +208,14 @@ final class SingPassJwtService implements SingPassJwtServiceInterface
 
         // Check if the client_id of the relaying party is SingPass
         $aud = $payload['aud'];
-        $singpassClientId = config('services.singpass-login.clientId');
+        $singpassClientId = config('singpass-login.clientId');
         if ($aud !== $singpassClientId) {
             throw new JwtPayloadException(400, 'Wrong client ID');
         }
 
         // Check if the principal is SingPass
         $iss = $payload['iss'];
-        $singpassDomain = config('services.singpass-login.domain');
+        $singpassDomain = config('singpass-login.domain');
         if ($iss !== $singpassDomain) {
             throw new JwtPayloadException(400, 'Came from wrong principal');
         }

--- a/tests/Unit/Http/Controllers/GetAuthenticationEndpointControllerTest.php
+++ b/tests/Unit/Http/Controllers/GetAuthenticationEndpointControllerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Accredifysg\SingPassLogin\Tests\Unit\Http\Controllers;
+
+use Accredifysg\SingPassLogin\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+
+class GetAuthenticationEndpointControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_a_valid_singpass_login_url()
+    {
+        // Mock the HTTP response
+        $mockResponse = '{"issuer":"https://example.com","authorization_endpoint":"https://example.com/auth"}';
+
+        Http::fake([
+            'https://example.com/discovery' => Http::response($mockResponse, 200),
+        ]);
+
+        // Mock configuration values
+        Config::set('singpass-login.discovery_endpoint', 'https://example.com/discovery');
+        Config::set('singpass-login.redirect_uri', 'http://redirect.uri');
+        Config::set('singpass-login.client_id', 'test-client-id');
+
+        // Call the route
+        $response = $this->getJson('/sp/login');
+
+        // Assert response is valid JSON
+        $response->assertStatus(200)
+            ->assertJsonStructure(['redirect_url']);
+
+        // Extract redirect URL from response
+        $redirectUrl = $response->json('redirect_url');
+
+        // Assert the URL contains expected query parameters
+        parse_str(parse_url($redirectUrl, PHP_URL_QUERY), $queryParams);
+
+        $this->assertEquals('http://redirect.uri', $queryParams['redirect_uri']);
+        $this->assertEquals('code', $queryParams['response_type']);
+        $this->assertStringStartsWith('LOGIN-', $queryParams['state']);
+        $this->assertEquals('openid', $queryParams['scope']);
+        $this->assertEquals('test-client-id', $queryParams['client_id']);
+        $this->assertNotEmpty($queryParams['nonce']); // Ensure nonce is generated
+    }
+}

--- a/tests/Unit/Http/Controllers/GetJwksEndpointControllerTest.php
+++ b/tests/Unit/Http/Controllers/GetJwksEndpointControllerTest.php
@@ -27,7 +27,7 @@ class GetJwksEndpointControllerTest extends TestCase
             ],
         ];
 
-        Config::set('services.singpass-login.jwks', json_encode($this->mockJwksContent));
+        Config::set('singpass-login.jwks', json_encode($this->mockJwksContent));
     }
 
     protected function tearDown(): void
@@ -54,7 +54,7 @@ class GetJwksEndpointControllerTest extends TestCase
     public function testInvokeThrowsExceptionWhenJwksFileIsInvalid()
     {
         // Replace the JWKS env var with invalid JSON
-        Config::set('services.singpass-login.jwks', 'invalid json');
+        Config::set('singpass-login.jwks', 'invalid json');
 
         $this->expectException(JwksInvalidException::class);
         $this->expectExceptionMessage('JWKS is an invalid JSON string.');
@@ -69,7 +69,7 @@ class GetJwksEndpointControllerTest extends TestCase
     public function testInvokeThrowsExceptionWhenJwksFileIsMissing()
     {
         // Delete the JWKS env var
-        Config::set('services.singpass-login.jwks');
+        Config::set('singpass-login.jwks');
 
         $this->expectException(JwksInvalidException::class);
         $this->expectExceptionMessage('JWKS environment variable not set.');

--- a/tests/Unit/Services/GetSingPassTokenServiceTest.php
+++ b/tests/Unit/Services/GetSingPassTokenServiceTest.php
@@ -32,8 +32,8 @@ class GetSingPassTokenServiceTest extends TestCase
     public function test_get_token_success()
     {
         // Mock configuration values
-        Config::set('services.singpass-login.clientId', 'test-client-id');
-        Config::set('services.singpass-login.redirectionUrl', 'https://example.com/callback');
+        Config::set('singpass-login.clientId', 'test-client-id');
+        Config::set('singpass-login.redirectionUrl', 'https://example.com/callback');
 
         // Mock SingPassJwtService methods
         $mockJwk = (object) ['kty' => 'RSA', 'kid' => 'test-key-id'];
@@ -67,8 +67,8 @@ class GetSingPassTokenServiceTest extends TestCase
     public function test_get_token_exception()
     {
         // Mock configuration values
-        Config::set('services.singpass-login.clientId', 'test-client-id');
-        Config::set('services.singpass-login.redirectionUrl', 'https://example.com/callback');
+        Config::set('singpass-login.clientId', 'test-client-id');
+        Config::set('singpass-login.redirectionUrl', 'https://example.com/callback');
 
         // Mock SingPassJwtService methods
         $mockJwk = (object) ['kty' => 'RSA', 'kid' => 'test-key-id'];

--- a/tests/Unit/Services/OpenIdDiscoveryServiceTest.php
+++ b/tests/Unit/Services/OpenIdDiscoveryServiceTest.php
@@ -15,7 +15,7 @@ class OpenIdDiscoveryServiceTest extends TestCase
     {
         parent::setUp();
         // You can set any necessary configuration here.
-        Config::set('services.singpass-login.discovery_endpoint', 'https://example.com/discovery');
+        Config::set('singpass-login.discovery_endpoint', 'https://example.com/discovery');
     }
 
     public function test_cache_open_id_discovery_success()

--- a/tests/Unit/Services/SingPassJwtService/GenerateClientAssertionTest.php
+++ b/tests/Unit/Services/SingPassJwtService/GenerateClientAssertionTest.php
@@ -14,8 +14,8 @@ class GenerateClientAssertionTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         // Set up default configuration values
-        $app['config']->set('services.singpass-login.clientId', 'test-client-id');
-        $app['config']->set('services.singpass-login.signingKid', 'test-signing-kid');
+        $app['config']->set('singpass-login.clientId', 'test-client-id');
+        $app['config']->set('singpass-login.signingKid', 'test-signing-kid');
     }
 
     public function test_generate_client_assertion_success()

--- a/tests/Unit/Services/SingPassJwtService/GetSigningJwkTest.php
+++ b/tests/Unit/Services/SingPassJwtService/GetSigningJwkTest.php
@@ -24,8 +24,8 @@ class GetSigningJwkTest extends TestCase
         ];
 
         // Set up default configuration values
-        Config::set('services.singpass-login.private_jwks', json_encode($keySet));
-        Config::set('services.singpass-login.signing_kid', 'test-kid-id');
+        Config::set('singpass-login.private_jwks', json_encode($keySet));
+        Config::set('singpass-login.signing_kid', 'test-kid-id');
 
         // Call the method
         $jwk = SingPassJwtService::getSigningJwk();
@@ -50,7 +50,7 @@ class GetSigningJwkTest extends TestCase
     public function test_get_signing_jwk_invalid_json_exception()
     {
         // Set up default configuration values
-        Config::set('services.singpass-login.private_jwks', '{{}');
+        Config::set('singpass-login.private_jwks', '{{}');
 
         // Expect the JwksInvalidException to be thrown
         $this->expectException(JwksInvalidException::class);
@@ -73,8 +73,8 @@ class GetSigningJwkTest extends TestCase
         ];
 
         // Set up default configuration values
-        Config::set('services.singpass-login.private_jwks', json_encode($keySet));
-        Config::set('services.singpass-login.signing_kid', 'test-kid-id');
+        Config::set('singpass-login.private_jwks', json_encode($keySet));
+        Config::set('singpass-login.signing_kid', 'test-kid-id');
 
         // Expect the JwksInvalidException to be thrown
         $this->expectException(JwksInvalidException::class);

--- a/tests/Unit/Services/SingPassJwtService/JweDecryptTest.php
+++ b/tests/Unit/Services/SingPassJwtService/JweDecryptTest.php
@@ -25,7 +25,7 @@ class JweDecryptTest extends TestCase
         $jwks = json_encode(['keys' => [$key->jsonSerialize()]]);
 
         // Mock configuration values
-        Config::set('services.singpass-login.private_jwks', $jwks);
+        Config::set('singpass-login.private_jwks', $jwks);
 
         // Create a mock JWE token
         $payload = 'test-payload';
@@ -45,7 +45,7 @@ class JweDecryptTest extends TestCase
         $jwks = json_encode(['keys' => [$key->jsonSerialize()]]);
 
         // Mock configuration values
-        Config::set('services.singpass-login.private_jwks', $jwks);
+        Config::set('singpass-login.private_jwks', $jwks);
 
         // Create a mock JWE token
         $payload = 'test-payload';
@@ -79,7 +79,7 @@ class JweDecryptTest extends TestCase
         $jwks = json_encode(['keys' => [$key->jsonSerialize()]]);
 
         // Mock configuration values
-        Config::set('services.singpass-login.private_jwks', $jwks. 1);
+        Config::set('singpass-login.private_jwks', $jwks. 1);
 
         // Create a mock JWE token
         $payload = 'test-payload';
@@ -101,7 +101,7 @@ class JweDecryptTest extends TestCase
         $jwks = json_encode(['keys' => [$wrongKey->jsonSerialize()]]);
 
         // Mock configuration values
-        Config::set('services.singpass-login.private_jwks', $jwks);
+        Config::set('singpass-login.private_jwks', $jwks);
 
         // Create a mock JWE token
         $payload = 'test-payload';

--- a/tests/Unit/Services/SingPassJwtService/VerifyPayloadTest.php
+++ b/tests/Unit/Services/SingPassJwtService/VerifyPayloadTest.php
@@ -13,8 +13,8 @@ class VerifyPayloadTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         // Set up default configuration values
-        $app['config']->set('services.singpass-login.clientId', 'test-client-id');
-        $app['config']->set('services.singpass-login.domain', 'test-domain');
+        $app['config']->set('singpass-login.clientId', 'test-client-id');
+        $app['config']->set('singpass-login.domain', 'test-domain');
     }
 
     public function test_verify_payload_success()
@@ -22,8 +22,8 @@ class VerifyPayloadTest extends TestCase
         // Mock configuration values
         $clientId = 'test-client-id';
         $domain = 'test-domain';
-        Config::set('services.singpass-login.clientId', $clientId);
-        Config::set('services.singpass-login.domain', $domain);
+        Config::set('singpass-login.clientId', $clientId);
+        Config::set('singpass-login.domain', $domain);
 
         // Create a valid payload
         $now = Carbon::now()->timestamp;
@@ -46,8 +46,8 @@ class VerifyPayloadTest extends TestCase
         // Mock configuration values
         $clientId = 'test-client-id';
         $domain = 'test-domain';
-        Config::set('services.singpass-login.clientId', $clientId);
-        Config::set('services.singpass-login.domain', $domain);
+        Config::set('singpass-login.clientId', $clientId);
+        Config::set('singpass-login.domain', $domain);
 
         // Create an expired payload
         $now = Carbon::now()->timestamp;
@@ -71,8 +71,8 @@ class VerifyPayloadTest extends TestCase
         // Mock configuration values
         $clientId = 'test-client-id';
         $domain = 'test-domain';
-        Config::set('services.singpass-login.clientId', $clientId);
-        Config::set('services.singpass-login.domain', $domain);
+        Config::set('singpass-login.clientId', $clientId);
+        Config::set('singpass-login.domain', $domain);
 
         // Create a payload with the wrong client ID
         $now = Carbon::now()->timestamp;
@@ -96,8 +96,8 @@ class VerifyPayloadTest extends TestCase
         // Mock configuration values
         $clientId = 'test-client-id';
         $domain = 'test-domain';
-        Config::set('services.singpass-login.clientId', $clientId);
-        Config::set('services.singpass-login.domain', $domain);
+        Config::set('singpass-login.clientId', $clientId);
+        Config::set('singpass-login.domain', $domain);
 
         // Create a payload with the wrong principal
         $now = Carbon::now()->timestamp;


### PR DESCRIPTION
## Proposed changes

Added a new authentication endpoint controller so that the frontend is able to retrieve the redirection uri required to kick start the SingPass authentication process.

## Checklist

- [x] Unit/Feature tests passed and maintained at 80% coverage
- [x] Label either `New feature`, `Bugfix`, `Breaking change`, `Refactoring`, `DevOps`, or `Documentation` on GitHub
- [x] I have reviewed the changes myself
- [x] I have added/updated tests that prove my fix is effective or that my feature works
