### PR TITLE
Updated Login Failure Behaviour

### DIFF
--- a/src/Exceptions/SingPassLoginException.php
+++ b/src/Exceptions/SingPassLoginException.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class SingPassLoginException extends HttpException
 {
-    public function __construct(int $statusCode = 400, string $message = 'User not found.', ?Exception $previous = null, array $headers = [], int $code = 0)
+    public function __construct(int $statusCode = 400, string $message = 'This SingPass account is not connected with any existing accounts in our system.', ?Exception $previous = null, array $headers = [], int $code = 0)
     {
         parent::__construct($statusCode, $message, $previous, $headers, $code);
     }
@@ -18,11 +18,11 @@ class SingPassLoginException extends HttpException
      */
     public function render(): RedirectResponse
     {
-        return redirect()->back()->withErrors(
+        return redirect()->route('login')->withErrors(
             [
                 'singpass' => [
                     [
-                        'title' => 'SingPass Login Error',
+                        'title' => 'No Account Found',
                         'description' => $this->message,
                     ],
                 ],

--- a/tests/Unit/Exceptions/SingPassLoginExceptionTest.php
+++ b/tests/Unit/Exceptions/SingPassLoginExceptionTest.php
@@ -6,6 +6,7 @@ use Accredifysg\SingPassLogin\Exceptions\SingPassLoginException;
 use Accredifysg\SingPassLogin\Exceptions\SingPassTokenException;
 use Accredifysg\SingPassLogin\Tests\TestCase;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class SingPassLoginExceptionTest extends TestCase
@@ -20,7 +21,7 @@ class SingPassLoginExceptionTest extends TestCase
     {
         $exception = new SingPassLoginException;
         $this->assertEquals(400, $exception->getStatusCode());
-        $this->assertEquals('User not found.', $exception->getMessage());
+        $this->assertEquals('This SingPass account is not connected with any existing accounts in our system.', $exception->getMessage());
     }
 
     public function testCustomValues(): void
@@ -32,17 +33,19 @@ class SingPassLoginExceptionTest extends TestCase
 
     public function testRender(): void
     {
+        Route::get('/login')->name('login');
+
         $exception = new SingPassLoginException;
 
         $response = $exception->render();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertEquals(url()->previous(), $response->getTargetUrl());
+        $this->assertEquals(route('login'), $response->getTargetUrl());
         $this->assertEquals([
             'singpass' => [
                 [
-                    'title' => 'SingPass Login Error',
-                    'description' => 'User not found.',
+                    'title' => 'No Account Found',
+                    'description' => 'This SingPass account is not connected with any existing accounts in our system.',
                 ],
             ],
         ], session('errors')->getBag('default')->messages());

--- a/tests/Unit/Http/Controllers/GetSingPassCallbackControllerTest.php
+++ b/tests/Unit/Http/Controllers/GetSingPassCallbackControllerTest.php
@@ -10,6 +10,7 @@ use Accredifysg\SingPassLogin\Tests\TestCase;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class GetSingPassCallbackControllerTest extends TestCase
@@ -42,6 +43,8 @@ class GetSingPassCallbackControllerTest extends TestCase
 
     public function testSingPassLoginExceptionRender(): void
     {
+        Route::get('/login')->name('login');
+
         // Mock the SingPassLogin class
         $singPassLoginMock = $this->createMock(SingPassLogin::class);
 
@@ -63,14 +66,14 @@ class GetSingPassCallbackControllerTest extends TestCase
         $this->assertInstanceOf(RedirectResponse::class, $response);
 
         // Assert that it redirects back
-        $this->assertEquals(url()->previous(), $response->getTargetUrl());
+        $this->assertEquals(route('login'), $response->getTargetUrl());
 
         // Assert that the session contains the expected error message
         $this->assertEquals([
             'singpass' => [
                 [
-                    'title' => 'SingPass Login Error',
-                    'description' => 'User not found.',
+                    'title' => 'No Account Found',
+                    'description' => 'This SingPass account is not connected with any existing accounts in our system.',
                 ],
             ],
         ], session('errors')->getBag('default')->messages());

--- a/tests/Unit/Listeners/SingPassSuccessfulLoginListenerTest.php
+++ b/tests/Unit/Listeners/SingPassSuccessfulLoginListenerTest.php
@@ -107,7 +107,7 @@ class SingPassSuccessfulLoginListenerTest extends TestCase
         $listener = new SingPassSuccessfulLoginListener;
 
         $this->expectException(SingPassLoginException::class);
-        $this->expectExceptionMessage('User not found.');
+        $this->expectExceptionMessage('This SingPass account is not connected with any existing accounts in our system.');
 
         $listener->handle($event);
     }


### PR DESCRIPTION
## Proposed changes

Changes the redirection upon failure to use a named login route instead of back due to back redirecting the browser to the json endpoint that retrieves the auth endpoint.

## Checklist

- [x] Unit/Feature tests passed and maintained at 80% coverage
- [x] Label either `New feature`, `Bugfix`, `Breaking change`, `Refactoring`, `DevOps`, or `Documentation` on GitHub
- [x] I have reviewed the changes myself
- [x] I have added/updated tests that prove my fix is effective or that my feature works
