### PR TITLE
Added catch when endpoint visited directly

### DIFF
--- a/src/Exceptions/SingPassGetEndpointException.php
+++ b/src/Exceptions/SingPassGetEndpointException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Accredifysg\SingPassLogin\Exceptions;
+
+use Exception;
+use Illuminate\Http\RedirectResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class SingPassGetEndpointException extends HttpException
+{
+    public function __construct(int $statusCode = 400, string $message = 'An error has occurred when processing your request.', ?Exception $previous = null, array $headers = [], int $code = 0)
+    {
+        parent::__construct($statusCode, $message, $previous, $headers, $code);
+    }
+
+    /**
+     * Render the exception into an HTTP response.
+     */
+    public function render(): RedirectResponse
+    {
+        return redirect()->route('login')->withErrors(
+            [
+                'singpass' => [
+                    [
+                        'title' => 'Request Error',
+                        'description' => $this->message,
+                    ],
+                ],
+            ]
+        );
+    }
+}

--- a/src/Http/Controllers/GetSingPassCallbackController.php
+++ b/src/Http/Controllers/GetSingPassCallbackController.php
@@ -2,6 +2,7 @@
 
 namespace Accredifysg\SingPassLogin\Http\Controllers;
 
+use Accredifysg\SingPassLogin\Exceptions\SingPassGetEndpointException;
 use Accredifysg\SingPassLogin\Exceptions\SingPassLoginException;
 use Accredifysg\SingPassLogin\Interfaces\SingPassLoginInterface;
 use Illuminate\Http\RedirectResponse;
@@ -20,8 +21,12 @@ class GetSingPassCallbackController extends Controller
         $codeVerifier = $request->cookie('code_verifier');
 
         try {
+            if (! $code || ! $state || ! $codeVerifier) {
+                throw new SingPassGetEndpointException;
+            }
+
             $singPassLogin->handleCallback($code, $state, $codeVerifier);
-        } catch (SingPassLoginException $e) {
+        } catch (SingPassLoginException|SingPassGetEndpointException $e) {
             return $e->render();
         }
 

--- a/tests/Unit/Http/Controllers/GetSingPassCallbackControllerTest.php
+++ b/tests/Unit/Http/Controllers/GetSingPassCallbackControllerTest.php
@@ -79,6 +79,41 @@ class GetSingPassCallbackControllerTest extends TestCase
         ], session('errors')->getBag('default')->messages());
     }
 
+    public function test_missing_required_parameters_throws_exception(): void
+    {
+        Route::get('/login')->name('login');
+
+        // Create an instance of the controller
+        $controller = new GetSingPassCallbackController;
+
+        // Create the request with missing parameters
+        $request = new Request([], [], [], []); // Empty request with no parameters
+
+        // Create a mock of SingPassLogin (though it shouldn't be called)
+        /** @var SingPassLogin|MockObject $singPassLoginMock */
+        $singPassLoginMock = $this->createMock(SingPassLogin::class);
+        $singPassLoginMock->expects($this->never())->method('handleCallback');
+
+        // Call the method and capture the response
+        $response = $controller->__invoke($request, $singPassLoginMock);
+
+        // Assert that the response is a redirect
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+
+        // Assert that it redirects to login
+        $this->assertEquals(route('login'), $response->getTargetUrl());
+
+        // Assert that the session contains the expected error message
+        $this->assertEquals([
+            'singpass' => [
+                [
+                    'title' => 'Request Error',
+                    'description' => 'An error has occurred when processing your request.',
+                ],
+            ],
+        ], session('errors')->getBag('default')->messages());
+    }
+
     protected function getPackageProviders($app): array
     {
         return [


### PR DESCRIPTION
## Proposed changes
Added a catch for when the endpoint's page is access directly or with missing parameters.

## Checklist
- [x] Unit/Feature tests passed and maintained at 80% coverage
- [x] Label either `New feature`, `Bugfix`, `Breaking change`, `Refactoring`, `DevOps`, or `Documentation` on GitHub
- [x] I have reviewed the changes myself
- [x] I have added/updated tests that prove my fix is effective or that my feature works