### PR TITLE
MyInfo Integration Part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ SINGPASS_CALLBACK_URL=/sp/callback
 
 # Default Listener
 SINGPASS_USE_DEFAULT_LISTENER=true
+
+# Optional MyInfo envs if you want to use MyInfo integration
+SINGPASS_MYINFO_CLIENT_ID=
+SINGPASS_MYINFO_REDIRECT_URI=
 ```
 
 Publish the config file

--- a/config/singpass-login.php
+++ b/config/singpass-login.php
@@ -29,6 +29,10 @@ return [
     'use_default_listener' => env('SINGPASS_USE_DEFAULT_LISTENER', true),
     'listener_class' => SingPassSuccessfulLoginListener::class,
 
+    // MyInfo
+    'myinfo_client_id' => env('SINGPASS_MYINFO_CLIENT_ID'),
+    'myinfo_redirect_uri' => env('SINGPASS_MYINFO_REDIRECT_URI'),
+
     /*
     |--------------------------------------------------------------------------
     | Available MyInfo Scopes

--- a/config/singpass-login.php
+++ b/config/singpass-login.php
@@ -25,9 +25,6 @@ return [
     'get_authentication_endpoint_controller' => GetAuthenticationEndpointController::class,
     'post_singpass_callback_controller' => GetSingPassCallbackController::class,
 
-    // Debug mode
-    'debug_mode' => env('SINGPASS_DEBUG_MODE', false),
-
     // Listener
     'use_default_listener' => env('SINGPASS_USE_DEFAULT_LISTENER', true),
     'listener_class' => SingPassSuccessfulLoginListener::class,

--- a/coverage/badge.svg
+++ b/coverage/badge.svg
@@ -1,5 +1,5 @@
-<svg width="192.6" height="20" viewBox="0 0 1926 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Test coverage: 98.38337182448">
-  <title>Test coverage: 98.38337182448</title>
+<svg width="192.6" height="20" viewBox="0 0 1926 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Test coverage: 98.41628959276">
+  <title>Test coverage: 98.41628959276</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="776" fill="#000" opacity="0.25">Test coverage</text>
     <text x="50" y="138" textLength="776">Test coverage</text>
-    <text x="931" y="148" textLength="950" fill="#000" opacity="0.25">98.38337182448</text>
-    <text x="921" y="138" textLength="950">98.38337182448</text>
+    <text x="931" y="148" textLength="950" fill="#000" opacity="0.25">98.41628959276</text>
+    <text x="921" y="138" textLength="950">98.41628959276</text>
   </g>
   
 </svg>

--- a/src/Http/Controllers/GetAuthenticationEndpointController.php
+++ b/src/Http/Controllers/GetAuthenticationEndpointController.php
@@ -23,18 +23,27 @@ class GetAuthenticationEndpointController extends Controller
         OpenIdDiscoveryService $discoveryService
     ): JsonResponse {
         $discoveryService->cacheOpenIdDiscovery();
-        $redirectUri = config('singpass-login.redirect_uri');
         $responseType = 'code';
-        $statePrefix = $request->query('state', 'LOGIN-');
-        $state = (is_string($statePrefix) ? $statePrefix : 'LOGIN-').Str::uuid();
 
         // Parse, validate, and normalize scopes
         $requestedScopes = $request->query('scopes', 'openid') ?? 'openid';
         $validatedScopes = $scopeService->parseAndValidate($requestedScopes);
         $scope = $scopeService->formatForOAuth($validatedScopes);
 
+        // Determine which client ID to use based on scopes
+        if ($scope === 'openid') {
+            $redirectUri = config('singpass-login.redirect_uri');
+            $clientID = config('singpass-login.client_id');
+            $statePrefix = $request->query('state', 'LOGIN-');
+            $state = (is_string($statePrefix) ? $statePrefix : 'LOGIN-').Str::uuid();
+        } else {
+            $redirectUri = config('singpass-login.myinfo_redirect_uri');
+            $clientID = config('singpass-login.myinfo_client_id');
+            $statePrefix = $request->query('state', 'MYINFO-');
+            $state = (is_string($statePrefix) ? $statePrefix : 'MYINFO-').Str::uuid();
+        }
+
         $singPassAuthenticationEndpoint = Cache::get('openId')->authorization_endpoint;
-        $clientID = config('singpass-login.client_id');
         $nonce = Str::uuid();
 
         // PKCE

--- a/src/Interfaces/GetSingPassTokenServiceInterface.php
+++ b/src/Interfaces/GetSingPassTokenServiceInterface.php
@@ -6,5 +6,5 @@ use Accredifysg\SingPassLogin\DTOs\TokenResponseDto;
 
 interface GetSingPassTokenServiceInterface
 {
-    public function getToken(string $code, string $codeVerifier): TokenResponseDto;
+    public function getToken(string $code, string $codeVerifier, string $state): TokenResponseDto;
 }

--- a/src/Services/GetSingPassTokenService.php
+++ b/src/Services/GetSingPassTokenService.php
@@ -17,15 +17,21 @@ final class GetSingPassTokenService implements GetSingPassTokenServiceInterface
      *
      * @throws ConnectionException
      */
-    public function getToken(string $code, string $codeVerifier): TokenResponseDto
+    public function getToken(string $code, string $codeVerifier, string $state): TokenResponseDto
     {
-        $clientId = config('singpass-login.client_id');
-        $redirectUrl = config('singpass-login.redirect_uri');
+        if (str_starts_with($state, 'MYINFO-')) {
+            $clientId = config('singpass-login.myinfo_client_id');
+            $redirectUrl = config('singpass-login.myinfo_redirect_uri');
+        } else {
+            $clientId = config('singpass-login.client_id');
+            $redirectUrl = config('singpass-login.redirect_uri');
+        }
+
         $grantType = 'authorization_code';
         $clientAssertionType = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
 
         $jwk = SingPassJwtService::getSigningJwk();
-        $clientAssertion = SingPassJwtService::generateClientAssertion($jwk, $code);
+        $clientAssertion = SingPassJwtService::generateClientAssertion($jwk, $code, $clientId);
 
         $response = Http::bodyFormat('form_params')
             ->contentType('application/x-www-form-urlencoded; charset=ISO-8859-1')

--- a/src/Services/SingPassJwtService.php
+++ b/src/Services/SingPassJwtService.php
@@ -22,6 +22,7 @@ use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Encryption\Algorithm\ContentEncryption\A256CBCHS512;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A256GCM;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\A256KW;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\ECDHESA256KW;
 use Jose\Component\Encryption\JWEDecrypter;
@@ -72,7 +73,7 @@ final class SingPassJwtService implements SingPassJwtServiceInterface
     /**
      * Generate the client assertion needed to retrieve a token to use for subsequent calls
      */
-    public static function generateClientAssertion(JWK $jwk, string $code): string
+    public static function generateClientAssertion(JWK $jwk, string $code, string $clientId): string
     {
         $algorithmManager = new AlgorithmManager([
             new ES512,
@@ -81,9 +82,9 @@ final class SingPassJwtService implements SingPassJwtServiceInterface
         $jwsBuilder = new JWSBuilder($algorithmManager);
 
         $payload = json_encode([
-            'sub' => config('singpass-login.client_id'),
+            'sub' => $clientId,
             'aud' => Cache::get('openId')->issuer,
-            'iss' => config('singpass-login.client_id'),
+            'iss' => $clientId,
             'iat' => time(),
             'exp' => time() + 119,
             'code' => $code,
@@ -121,6 +122,7 @@ final class SingPassJwtService implements SingPassJwtServiceInterface
             new A256KW,
             new ECDHESA256KW,
             new A256CBCHS512,
+            new A256GCM,
         ]);
 
         $serializerManager = new JWESerializerManager([

--- a/src/SingPassLogin.php
+++ b/src/SingPassLogin.php
@@ -27,12 +27,7 @@ readonly class SingPassLogin implements SingPassLoginInterface
     public function handleCallback(string $code, string $state, string $codeVerifier): void
     {
         $this->openIdDiscoveryService->cacheOpenIdDiscovery();
-        $tokenResponseDto = $this->getSingPassTokenService->getToken($code, $codeVerifier);
-        $jwtToken = $this->singPassJwtService->jweDecrypt($tokenResponseDto->idToken);
-        $jwksKeyset = $this->getSingPassJwksService->getSingPassJwks();
-        $payload = $this->singPassJwtService->jwtDecode($jwtToken, $jwksKeyset);
-        $this->singPassJwtService->verifyPayload($payload);
-        $singPassUser = $this->getSingPassUser($payload);
+        $tokenResponseDto = $this->getSingPassTokenService->getToken($code, $codeVerifier, $state);
 
         // Check if MyInfo data should be retrieved
         if ($tokenResponseDto->hasAccessToken() && $tokenResponseDto->accessToken !== null
@@ -45,6 +40,11 @@ readonly class SingPassLogin implements SingPassLoginInterface
             }
         } else {
             // Authentication only - emit login event
+            $jwtToken = $this->singPassJwtService->jweDecrypt($tokenResponseDto->idToken);
+            $jwksKeyset = $this->getSingPassJwksService->getSingPassJwks();
+            $payload = $this->singPassJwtService->jwtDecode($jwtToken, $jwksKeyset);
+            $this->singPassJwtService->verifyPayload($payload);
+            $singPassUser = $this->getSingPassUser($payload);
             event(new SingPassSuccessfulLoginEvent($singPassUser, $state));
         }
     }

--- a/tests/Feature/SingPassLoginTest.php
+++ b/tests/Feature/SingPassLoginTest.php
@@ -45,7 +45,7 @@ class SingPassLoginTest extends TestCase
         // Set expectations on mock services
         $openIdDiscoveryService->expects($this->once())->method('cacheOpenIdDiscovery');
         $getSingPassTokenService->expects($this->once())->method('getToken')
-            ->with('test_code', 'test-code-verifier')
+            ->with('test_code', 'test-code-verifier', 'test-state')
             ->willReturn($tokenResponseDto);
         $singPassJwtService->expects($this->once())->method('jweDecrypt')
             ->with('jwe_token')
@@ -92,18 +92,6 @@ class SingPassLoginTest extends TestCase
         $getSingPassJwksService = $this->createMock(GetSingPassJwksServiceInterface::class);
         $getUserInfoService = $this->createMock(GetUserInfoServiceInterface::class);
 
-        $jwks = JWKSet::createFromKeyData([
-            'keys' => [
-                [
-                    'kty' => 'RSA',
-                    'kid' => '1b94c',
-                    'use' => 'sig',
-                    'n' => '...',
-                    'e' => 'AQAB',
-                ],
-            ],
-        ]);
-
         $tokenResponseDto = new TokenResponseDto('jwe_token', 'access_token_value');
         $myInfoData = [
             'sub' => 's=S8829314B,u=1c0cee38-3a8f-4f8a-83bc-7a0e4c59d6a9',
@@ -114,18 +102,13 @@ class SingPassLoginTest extends TestCase
         // Set expectations on mock services
         $openIdDiscoveryService->expects($this->once())->method('cacheOpenIdDiscovery');
         $getSingPassTokenService->expects($this->once())->method('getToken')
-            ->with('test_code', 'test-code-verifier')
+            ->with('test_code', 'test-code-verifier', 'test-state')
             ->willReturn($tokenResponseDto);
-        $singPassJwtService->expects($this->once())->method('jweDecrypt')
-            ->with('jwe_token')
-            ->willReturn('jwt_token');
-        $getSingPassJwksService->expects($this->once())->method('getSingPassJwks')
-            ->willReturn($jwks);
-        $singPassJwtService->expects($this->once())->method('jwtDecode')
-            ->with('jwt_token', $jwks)
-            ->willReturn(['sub' => 's=S8829314B,u=1c0cee38-3a8f-4f8a-83bc-7a0e4c59d6a9']);
-        $singPassJwtService->expects($this->once())->method('verifyPayload')
-            ->with(['sub' => 's=S8829314B,u=1c0cee38-3a8f-4f8a-83bc-7a0e4c59d6a9']);
+        // Note: JWT decryption/decoding is NOT called for MyInfo flow (it's in the else block)
+        $singPassJwtService->expects($this->never())->method('jweDecrypt');
+        $getSingPassJwksService->expects($this->never())->method('getSingPassJwks');
+        $singPassJwtService->expects($this->never())->method('jwtDecode');
+        $singPassJwtService->expects($this->never())->method('verifyPayload');
         $getUserInfoService->expects($this->once())->method('shouldCallUserInfo')
             ->with('access_token_value')
             ->willReturn(true);

--- a/tests/Unit/Http/Controllers/GetAuthenticationEndpointControllerTest.php
+++ b/tests/Unit/Http/Controllers/GetAuthenticationEndpointControllerTest.php
@@ -60,6 +60,8 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         Config::set('singpass-login.discovery_endpoint', 'https://example.com/discovery');
         Config::set('singpass-login.redirect_uri', 'http://redirect.uri');
         Config::set('singpass-login.client_id', 'test-client-id');
+        Config::set('singpass-login.myinfo_redirect_uri', 'http://myinfo-redirect.uri');
+        Config::set('singpass-login.myinfo_client_id', 'myinfo-client-id');
         Config::set('singpass-login.available_scopes', ['openid', 'name', 'email', 'mobileno']);
 
         // Call the route with scopes
@@ -75,6 +77,10 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         parse_str(parse_url($redirectUrl, PHP_URL_QUERY) ?: '', $queryParams);
 
         $this->assertEquals('openid name email', $queryParams['scope']);
+        // When scope is NOT just 'openid', use MyInfo client ID and redirect URI
+        $this->assertEquals('myinfo-client-id', $queryParams['client_id']);
+        $this->assertEquals('http://myinfo-redirect.uri', $queryParams['redirect_uri']);
+        $this->assertStringStartsWith('MYINFO-', $queryParams['state']);
     }
 
     public function test_it_accepts_scopes_as_array(): void
@@ -90,6 +96,8 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         Config::set('singpass-login.discovery_endpoint', 'https://example.com/discovery');
         Config::set('singpass-login.redirect_uri', 'http://redirect.uri');
         Config::set('singpass-login.client_id', 'test-client-id');
+        Config::set('singpass-login.myinfo_redirect_uri', 'http://myinfo-redirect.uri');
+        Config::set('singpass-login.myinfo_client_id', 'myinfo-client-id');
         Config::set('singpass-login.available_scopes', ['openid', 'name', 'email', 'mobileno']);
 
         // Call the route with scopes as array
@@ -105,6 +113,10 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         parse_str(parse_url($redirectUrl, PHP_URL_QUERY) ?: '', $queryParams);
 
         $this->assertEquals('openid name email', $queryParams['scope']);
+        // When scope is NOT just 'openid', use MyInfo client ID and redirect URI
+        $this->assertEquals('myinfo-client-id', $queryParams['client_id']);
+        $this->assertEquals('http://myinfo-redirect.uri', $queryParams['redirect_uri']);
+        $this->assertStringStartsWith('MYINFO-', $queryParams['state']);
     }
 
     public function test_it_throws_exception_for_invalid_scopes(): void
@@ -123,6 +135,8 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         Config::set('singpass-login.discovery_endpoint', 'https://example.com/discovery');
         Config::set('singpass-login.redirect_uri', 'http://redirect.uri');
         Config::set('singpass-login.client_id', 'test-client-id');
+        Config::set('singpass-login.myinfo_redirect_uri', 'http://myinfo-redirect.uri');
+        Config::set('singpass-login.myinfo_client_id', 'myinfo-client-id');
         Config::set('singpass-login.available_scopes', ['openid', 'name', 'email']);
 
         // Expect an InvalidArgumentException to be thrown
@@ -146,6 +160,8 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         Config::set('singpass-login.discovery_endpoint', 'https://example.com/discovery');
         Config::set('singpass-login.redirect_uri', 'http://redirect.uri');
         Config::set('singpass-login.client_id', 'test-client-id');
+        Config::set('singpass-login.myinfo_redirect_uri', 'http://myinfo-redirect.uri');
+        Config::set('singpass-login.myinfo_client_id', 'myinfo-client-id');
         Config::set('singpass-login.available_scopes', ['openid', 'name', 'email']);
 
         // Call the route with scopes that don't include openid
@@ -161,6 +177,9 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         parse_str(parse_url($redirectUrl, PHP_URL_QUERY) ?: '', $queryParams);
 
         $this->assertEquals('openid name email', $queryParams['scope']);
+        // When scope has more than just 'openid', use MyInfo credentials
+        $this->assertEquals('myinfo-client-id', $queryParams['client_id']);
+        $this->assertStringStartsWith('MYINFO-', $queryParams['state']);
     }
 
     public function test_it_allows_openid_even_when_not_in_available_scopes_config(): void
@@ -176,6 +195,8 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         Config::set('singpass-login.discovery_endpoint', 'https://example.com/discovery');
         Config::set('singpass-login.redirect_uri', 'http://redirect.uri');
         Config::set('singpass-login.client_id', 'test-client-id');
+        Config::set('singpass-login.myinfo_redirect_uri', 'http://myinfo-redirect.uri');
+        Config::set('singpass-login.myinfo_client_id', 'myinfo-client-id');
         // Set available_scopes WITHOUT 'openid' - this should trigger line 72
         Config::set('singpass-login.available_scopes', ['name', 'email', 'mobileno']);
 
@@ -192,6 +213,8 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         parse_str(parse_url($redirectUrl, PHP_URL_QUERY) ?: '', $queryParams);
 
         $this->assertEquals('openid name email', $queryParams['scope']);
+        // Since scope is more than just 'openid', MyInfo credentials are used
+        $this->assertEquals('myinfo-client-id', $queryParams['client_id']);
     }
 
     public function test_it_defaults_to_openid_scope_when_available_scopes_missing_openid(): void

--- a/tests/Unit/Http/Controllers/GetAuthenticationEndpointControllerTest.php
+++ b/tests/Unit/Http/Controllers/GetAuthenticationEndpointControllerTest.php
@@ -80,6 +80,7 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         // When scope is NOT just 'openid', use MyInfo client ID and redirect URI
         $this->assertEquals('myinfo-client-id', $queryParams['client_id']);
         $this->assertEquals('http://myinfo-redirect.uri', $queryParams['redirect_uri']);
+        $this->assertIsString($queryParams['state']);
         $this->assertStringStartsWith('MYINFO-', $queryParams['state']);
     }
 
@@ -116,6 +117,7 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         // When scope is NOT just 'openid', use MyInfo client ID and redirect URI
         $this->assertEquals('myinfo-client-id', $queryParams['client_id']);
         $this->assertEquals('http://myinfo-redirect.uri', $queryParams['redirect_uri']);
+        $this->assertIsString($queryParams['state']);
         $this->assertStringStartsWith('MYINFO-', $queryParams['state']);
     }
 
@@ -179,6 +181,7 @@ class GetAuthenticationEndpointControllerTest extends TestCase
         $this->assertEquals('openid name email', $queryParams['scope']);
         // When scope has more than just 'openid', use MyInfo credentials
         $this->assertEquals('myinfo-client-id', $queryParams['client_id']);
+        $this->assertIsString($queryParams['state']);
         $this->assertStringStartsWith('MYINFO-', $queryParams['state']);
     }
 

--- a/tests/Unit/Services/GetSingPassTokenServiceTest.php
+++ b/tests/Unit/Services/GetSingPassTokenServiceTest.php
@@ -56,8 +56,44 @@ class GetSingPassTokenServiceTest extends TestCase
             'https://example.com/token' => Http::response($mockResponse, 200),
         ]);
 
-        // Call the method
-        $tokenResponse = (new GetSingPassTokenService)->getToken('mock-code', 'test-code-verifier');
+        // Call the method with LOGIN- state (regular auth flow)
+        $tokenResponse = (new GetSingPassTokenService)->getToken('mock-code', 'test-code-verifier', 'LOGIN-test-state');
+
+        // Assert the method returns the expected TokenResponseDto
+        $this->assertInstanceOf(TokenResponseDto::class, $tokenResponse);
+        $this->assertEquals('mock-id-token', $tokenResponse->idToken);
+        $this->assertEquals('mock-access-token', $tokenResponse->accessToken);
+        $this->assertTrue($tokenResponse->hasAccessToken());
+    }
+
+    public function test_get_token_with_myinfo_state(): void
+    {
+        // Mock configuration values for MyInfo
+        Config::set('singpass-login.myinfo_client_id', 'myinfo-client-id');
+        Config::set('singpass-login.myinfo_redirect_uri', 'https://example.com/myinfo-callback');
+
+        // Mock SingPassJwtService methods
+        $mockJwk = (object) ['kty' => 'RSA', 'kid' => 'test-key-id'];
+        $mockClientAssertion = 'mock-client-assertion';
+
+        $singPassJwtServiceMock = Mockery::mock('alias:'.SingPassJwtService::class);
+        $singPassJwtServiceMock->allows([
+            'getSigningJwk' => $mockJwk,
+            'generateClientAssertion' => $mockClientAssertion,
+        ]);
+
+        // Mock the HTTP response
+        $mockResponse = [
+            'id_token' => 'mock-id-token',
+            'access_token' => 'mock-access-token',
+        ];
+
+        Http::fake([
+            'https://example.com/token' => Http::response($mockResponse, 200),
+        ]);
+
+        // Call the method with MYINFO- state prefix
+        $tokenResponse = (new GetSingPassTokenService)->getToken('mock-code', 'test-code-verifier', 'MYINFO-test-state');
 
         // Assert the method returns the expected TokenResponseDto
         $this->assertInstanceOf(TokenResponseDto::class, $tokenResponse);
@@ -92,7 +128,7 @@ class GetSingPassTokenServiceTest extends TestCase
         ]);
 
         // Call the method
-        $tokenResponse = (new GetSingPassTokenService)->getToken('mock-code', 'test-code-verifier');
+        $tokenResponse = (new GetSingPassTokenService)->getToken('mock-code', 'test-code-verifier', 'LOGIN-test-state');
 
         // Assert the method returns TokenResponseDto with null accessToken
         $this->assertInstanceOf(TokenResponseDto::class, $tokenResponse);
@@ -126,6 +162,6 @@ class GetSingPassTokenServiceTest extends TestCase
         $this->expectException(SingPassTokenException::class);
 
         // Call the method
-        (new GetSingPassTokenService)->getToken('mock-code', 'test-code-verifier');
+        (new GetSingPassTokenService)->getToken('mock-code', 'test-code-verifier', 'LOGIN-test-state');
     }
 }

--- a/tests/Unit/Services/SingPassJwtService/GenerateClientAssertionTest.php
+++ b/tests/Unit/Services/SingPassJwtService/GenerateClientAssertionTest.php
@@ -39,8 +39,8 @@ class GenerateClientAssertionTest extends TestCase
             'alg' => 'ES512',
         ]);
 
-        // Call the method
-        $clientAssertion = SingPassJwtService::generateClientAssertion($jwk, 'mock-code');
+        // Call the method with explicit client ID
+        $clientAssertion = SingPassJwtService::generateClientAssertion($jwk, 'mock-code', 'test-client-id');
 
         // Assert the client assertion is a non-empty string
         $this->assertNotEmpty($clientAssertion);
@@ -58,7 +58,51 @@ class GenerateClientAssertionTest extends TestCase
         $this->assertEquals('test-client-id', $payload['iss']);
         $this->assertArrayHasKey('iat', $payload);
         $this->assertArrayHasKey('exp', $payload);
-        $this->assertEquals('mock-code', 'mock-code');
+        $this->assertEquals('mock-code', $payload['code']);
+    }
+
+    public function test_generate_client_assertion_with_myinfo_client_id(): void
+    {
+        // Mock Cache to return expected 'openId' values
+        Cache::shouldReceive('get')
+            ->with('openId')
+            ->andReturn((object) [
+                'issuer' => 'https://example.com',
+            ]);
+
+        // Create a mock JWK object
+        $jwk = new JWK([
+            'kty' => 'EC',
+            'd' => 'AMLSmZWRqxafLBkg88gNp-jf3KD9WqYo66RsBIjUBM76OwVOqgHmUR5LhtReXBTiziXaVrWo1bPAZgfn7u_vpK11',
+            'use' => 'sig',
+            'crv' => 'P-521',
+            'kid' => 'test-signing-kid',
+            'x' => 'Abyt-Y7n4eBXxDaV3TdUjcyHstOxdaG427PDy77uDlGHg4KgwLh512UsTlaKpdF-E4gQjykbCNulwZHdGZHb3Qxe',
+            'y' => 'AMTLon1XR5Ve71-t5AXPFPB3O42Ac96wlaHh6wnOkpJYO92_lzL3JEDu32i7alkckl8CrW6SlQCHJ6CFBBL4g2dk',
+            'alg' => 'ES512',
+        ]);
+
+        // Call the method with MyInfo client ID
+        $clientAssertion = SingPassJwtService::generateClientAssertion($jwk, 'mock-code', 'myinfo-client-id');
+
+        // Assert the client assertion is a non-empty string
+        $this->assertNotEmpty($clientAssertion);
+
+        // Further validate the JWS structure
+        $serializer = new JwsCompactSerializer;
+        $jws = $serializer->unserialize($clientAssertion);
+
+        $this->assertEquals(1, $jws->countSignatures());
+
+        $payload = json_decode($jws->getPayload() ?: '{}', true);
+
+        // Verify MyInfo client ID is used in sub and iss claims
+        $this->assertEquals('myinfo-client-id', $payload['sub']);
+        $this->assertEquals('https://example.com', $payload['aud']);
+        $this->assertEquals('myinfo-client-id', $payload['iss']);
+        $this->assertArrayHasKey('iat', $payload);
+        $this->assertArrayHasKey('exp', $payload);
+        $this->assertEquals('mock-code', $payload['code']);
     }
 
     public function test_generate_client_assertion_jwk_failure(): void
@@ -86,7 +130,7 @@ class GenerateClientAssertionTest extends TestCase
         $this->expectException(JwksInvalidException::class);
 
         // Call the method
-        SingPassJwtService::generateClientAssertion($jwk, 'mock-code');
+        SingPassJwtService::generateClientAssertion($jwk, 'mock-code', 'test-client-id');
     }
 
     public function test_generate_client_assertion_json_encode_failure(): void
@@ -120,6 +164,6 @@ class GenerateClientAssertionTest extends TestCase
         $this->expectExceptionMessage('Failed to encode JWT payload.');
 
         // Call the method
-        SingPassJwtService::generateClientAssertion($jwk, 'mock-code');
+        SingPassJwtService::generateClientAssertion($jwk, 'mock-code', 'test-client-id');
     }
 }

--- a/tests/Unit/SingPassLoginServiceProviderTest.php
+++ b/tests/Unit/SingPassLoginServiceProviderTest.php
@@ -66,6 +66,8 @@ class SingPassLoginServiceProviderTest extends TestCase
         $this->assertArrayHasKey('post_singpass_callback_controller', config('singpass-login'));
         $this->assertArrayHasKey('use_default_listener', config('singpass-login'));
         $this->assertArrayHasKey('listener_class', config('singpass-login'));
+        $this->assertArrayHasKey('myinfo_client_id', config('singpass-login'));
+        $this->assertArrayHasKey('myinfo_redirect_uri', config('singpass-login'));
     }
 
     protected function setUp(): void

--- a/tests/Unit/SingPassLoginServiceProviderTest.php
+++ b/tests/Unit/SingPassLoginServiceProviderTest.php
@@ -64,7 +64,6 @@ class SingPassLoginServiceProviderTest extends TestCase
         $this->assertArrayHasKey('post_singpass_callback_url', config('singpass-login'));
         $this->assertArrayHasKey('get_jwks_endpoint_controller', config('singpass-login'));
         $this->assertArrayHasKey('post_singpass_callback_controller', config('singpass-login'));
-        $this->assertArrayHasKey('debug_mode', config('singpass-login'));
         $this->assertArrayHasKey('use_default_listener', config('singpass-login'));
         $this->assertArrayHasKey('listener_class', config('singpass-login'));
     }


### PR DESCRIPTION
## Proposed changes

This pull request adds support for MyInfo integration in the SingPass login flow, enabling the use of separate client credentials and redirect URIs when MyInfo scopes are requested. It introduces new configuration options and updates the authentication and token exchange logic to handle both standard SingPass and MyInfo flows. The test suite has been updated to cover these changes and ensure correct behavior.

**MyInfo Integration Support:**

* Added new environment variables and configuration options (`myinfo_client_id`, `myinfo_redirect_uri`) for MyInfo integration in `README.md` and `config/singpass-login.php`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R41) [[2]](diffhunk://#diff-df93020277ea7849d84de309fee11a343bb4530dac57aef1f5c00943574ecaf8L28-R35)
* Updated `GetAuthenticationEndpointController` to select MyInfo credentials and redirect URIs when scopes beyond `openid` are requested, and to use a different state prefix for MyInfo flows.

**Token Exchange and JWT Assertion Updates:**

* Modified `GetSingPassTokenService` and `GetSingPassTokenServiceInterface` to accept the `state` parameter and select the appropriate client credentials and redirect URI based on the state. [[1]](diffhunk://#diff-71a970deb5e27cae6367f394b95a1bde24f83ba51be2417b89c462d23272f033L9-R9) [[2]](diffhunk://#diff-656ae277132a606d889a1c83ea7912152ce5e84337aacba5c96e614324c8ccb8L20-R34)
* Updated `SingPassJwtService::generateClientAssertion` to use the correct client ID for the assertion payload. [[1]](diffhunk://#diff-d648ce6f32f3086b2dc0dada5031766cc001a60edb16e81a8402d32af8963776L75-R76) [[2]](diffhunk://#diff-d648ce6f32f3086b2dc0dada5031766cc001a60edb16e81a8402d32af8963776L84-R87)
* Added support for the `A256GCM` encryption algorithm in JWT decryption.

**Callback Handling Logic:**

* Refactored `SingPassLogin::handleCallback` to pass the `state` to the token service and only perform JWT decryption/verification for standard SingPass logins, not for MyInfo flows. [[1]](diffhunk://#diff-483e12941328a07f2fdc7b5a462767f5695d5bbfdcf7c85fcefd1c1fcc1a64a9L30-R30) [[2]](diffhunk://#diff-483e12941328a07f2fdc7b5a462767f5695d5bbfdcf7c85fcefd1c1fcc1a64a9R43-R47)

**Testing Improvements:**

* Updated and extended unit and feature tests to verify correct handling of MyInfo credentials, state prefixes, and to ensure JWT decryption is only called for the appropriate flows. [[1]](diffhunk://#diff-94d5f3cdf88adcb4cb0d27069d61a6bebc01af8581b308f3113eeb327e867b54L48-R48) [[2]](diffhunk://#diff-94d5f3cdf88adcb4cb0d27069d61a6bebc01af8581b308f3113eeb327e867b54L95-L106) [[3]](diffhunk://#diff-94d5f3cdf88adcb4cb0d27069d61a6bebc01af8581b308f3113eeb327e867b54L117-R111) [[4]](diffhunk://#diff-5c01f6b7be6b9a86570a5982609cc4cd677d1f42b5f02daf9d6aa860fb3c25b0R63-R64) [[5]](diffhunk://#diff-5c01f6b7be6b9a86570a5982609cc4cd677d1f42b5f02daf9d6aa860fb3c25b0R80-R84) [[6]](diffhunk://#diff-5c01f6b7be6b9a86570a5982609cc4cd677d1f42b5f02daf9d6aa860fb3c25b0R100-R101) [[7]](diffhunk://#diff-5c01f6b7be6b9a86570a5982609cc4cd677d1f42b5f02daf9d6aa860fb3c25b0R117-R121) [[8]](diffhunk://#diff-5c01f6b7be6b9a86570a5982609cc4cd677d1f42b5f02daf9d6aa860fb3c25b0R140-R141) [[9]](diffhunk://#diff-5c01f6b7be6b9a86570a5982609cc4cd677d1f42b5f02daf9d6aa860fb3c25b0R165-R166) [[10]](diffhunk://#diff-5c01f6b7be6b9a86570a5982609cc4cd677d1f42b5f02daf9d6aa860fb3c25b0R182-R185) [[11]](diffhunk://#diff-5c01f6b7be6b9a86570a5982609cc4cd677d1f42b5f02daf9d6aa860fb3c25b0R201-R202) [[12]](diffhunk://#diff-5c01f6b7be6b9a86570a5982609cc4cd677d1f42b5f02daf9d6aa860fb3c25b0R219-R220)

## Checklist

- [x] Unit/Feature tests passed and maintained at 80% coverage
- [x] Label either `New feature`, `Bugfix`, `Breaking change`, `Refactoring`, `DevOps`, or `Documentation` on GitHub
- [x] I have reviewed the changes myself
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)
