### PR TITLE
Declare Strict Types

### DIFF
--- a/config/corppass-login.php
+++ b/config/corppass-login.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Accredifysg\SingPassLogin\Http\Controllers\CorpPass\LoginCallbackController;
 use Accredifysg\SingPassLogin\Http\Controllers\CorpPass\LoginController;
 use Accredifysg\SingPassLogin\Listeners\CorpPassSuccessfulLoginListener;

--- a/config/myinfo.php
+++ b/config/myinfo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Accredifysg\SingPassLogin\Http\Controllers\SingPass\MyInfoCallbackController;
 use Accredifysg\SingPassLogin\Http\Controllers\SingPass\MyInfoController;
 

--- a/config/ndi.php
+++ b/config/ndi.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Accredifysg\SingPassLogin\Http\Controllers\GetJwksEndpointController;
 
 return [

--- a/config/singpass-login.php
+++ b/config/singpass-login.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Accredifysg\SingPassLogin\Http\Controllers\SingPass\LoginCallbackController;
 use Accredifysg\SingPassLogin\Http\Controllers\SingPass\LoginController;
 use Accredifysg\SingPassLogin\Listeners\SingPassSuccessfulLoginListener;

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Database\Factories;
 
 use Accredifysg\SingPassLogin\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
 /**

--- a/database/migrations/add_corppass_entity_id_to_users_table.php
+++ b/database/migrations/add_corppass_entity_id_to_users_table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/add_nric_to_users_table.php
+++ b/database/migrations/add_nric_to_users_table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('web')->group(function () {

--- a/src/DTOs/FapiCallbackResult.php
+++ b/src/DTOs/FapiCallbackResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\DTOs;
 
 readonly class FapiCallbackResult

--- a/src/DTOs/FapiSessionContext.php
+++ b/src/DTOs/FapiSessionContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\DTOs;
 
 use Jose\Component\Core\JWK;

--- a/src/DTOs/OpenIdConfigurationDto.php
+++ b/src/DTOs/OpenIdConfigurationDto.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\DTOs;
 
 use Accredifysg\SingPassLogin\Exceptions\OpenIdDiscoveryException;

--- a/src/DTOs/ProviderConfig.php
+++ b/src/DTOs/ProviderConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\DTOs;
 
 use Accredifysg\SingPassLogin\Exceptions\MissingConfigException;

--- a/src/DTOs/TokenResponseDto.php
+++ b/src/DTOs/TokenResponseDto.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\DTOs;
 
 readonly class TokenResponseDto

--- a/src/Events/CorpPassDataRetrievedEvent.php
+++ b/src/Events/CorpPassDataRetrievedEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Events;
 
 readonly class CorpPassDataRetrievedEvent

--- a/src/Events/CorpPassSuccessfulLoginEvent.php
+++ b/src/Events/CorpPassSuccessfulLoginEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Events;
 
 use Accredifysg\SingPassLogin\Models\CorpPassUser;

--- a/src/Events/MyInfoDataRetrievedEvent.php
+++ b/src/Events/MyInfoDataRetrievedEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Events;
 
 /**

--- a/src/Events/SingPassSuccessfulLoginEvent.php
+++ b/src/Events/SingPassSuccessfulLoginEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Events;
 
 use Accredifysg\SingPassLogin\Models\SingPassUser;

--- a/src/Exceptions/AuthFlowException.php
+++ b/src/Exceptions/AuthFlowException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/AuthenticationErrorException.php
+++ b/src/Exceptions/AuthenticationErrorException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/CorpPassLoginException.php
+++ b/src/Exceptions/CorpPassLoginException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/JweDecryptionFailedException.php
+++ b/src/Exceptions/JweDecryptionFailedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/JwksException.php
+++ b/src/Exceptions/JwksException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/JwksInvalidException.php
+++ b/src/Exceptions/JwksInvalidException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/JwtDecodeFailedException.php
+++ b/src/Exceptions/JwtDecodeFailedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/JwtPayloadException.php
+++ b/src/Exceptions/JwtPayloadException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/MissingConfigException.php
+++ b/src/Exceptions/MissingConfigException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use RuntimeException;

--- a/src/Exceptions/OpenIdDiscoveryException.php
+++ b/src/Exceptions/OpenIdDiscoveryException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/PushedAuthorizationRequestException.php
+++ b/src/Exceptions/PushedAuthorizationRequestException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/SingPassLoginException.php
+++ b/src/Exceptions/SingPassLoginException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/TokenExchangeException.php
+++ b/src/Exceptions/TokenExchangeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/UserInfoDecryptionException.php
+++ b/src/Exceptions/UserInfoDecryptionException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/UserInfoRequestException.php
+++ b/src/Exceptions/UserInfoRequestException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Exceptions/UserInfoVerificationException.php
+++ b/src/Exceptions/UserInfoVerificationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Exceptions;
 
 use Exception;

--- a/src/Http/Controllers/CorpPass/LoginCallbackController.php
+++ b/src/Http/Controllers/CorpPass/LoginCallbackController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Http\Controllers\CorpPass;
 
 use Accredifysg\SingPassLogin\DTOs\ProviderConfig;

--- a/src/Http/Controllers/CorpPass/LoginController.php
+++ b/src/Http/Controllers/CorpPass/LoginController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Http\Controllers\CorpPass;
 
 use Accredifysg\SingPassLogin\DTOs\ProviderConfig;

--- a/src/Http/Controllers/GetJwksEndpointController.php
+++ b/src/Http/Controllers/GetJwksEndpointController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Http\Controllers;
 
 use Accredifysg\SingPassLogin\Exceptions\JwksInvalidException;

--- a/src/Http/Controllers/SingPass/LoginCallbackController.php
+++ b/src/Http/Controllers/SingPass/LoginCallbackController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Http\Controllers\SingPass;
 
 use Accredifysg\SingPassLogin\DTOs\ProviderConfig;

--- a/src/Http/Controllers/SingPass/LoginController.php
+++ b/src/Http/Controllers/SingPass/LoginController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Http\Controllers\SingPass;
 
 use Accredifysg\SingPassLogin\DTOs\ProviderConfig;

--- a/src/Http/Controllers/SingPass/MyInfoCallbackController.php
+++ b/src/Http/Controllers/SingPass/MyInfoCallbackController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Http\Controllers\SingPass;
 
 use Accredifysg\SingPassLogin\DTOs\ProviderConfig;

--- a/src/Http/Controllers/SingPass/MyInfoController.php
+++ b/src/Http/Controllers/SingPass/MyInfoController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Http\Controllers\SingPass;
 
 use Accredifysg\SingPassLogin\DTOs\ProviderConfig;

--- a/src/Interfaces/CodeChallengeVerifierServiceInterface.php
+++ b/src/Interfaces/CodeChallengeVerifierServiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Interfaces;
 
 interface CodeChallengeVerifierServiceInterface

--- a/src/Interfaces/DPoPServiceInterface.php
+++ b/src/Interfaces/DPoPServiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Interfaces;
 
 use Jose\Component\Core\JWK;

--- a/src/Interfaces/GetUserInfoServiceInterface.php
+++ b/src/Interfaces/GetUserInfoServiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Interfaces;
 
 use Jose\Component\Core\JWK;

--- a/src/Interfaces/JwksServiceInterface.php
+++ b/src/Interfaces/JwksServiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Interfaces;
 
 use Jose\Component\Core\JWKSet;

--- a/src/Interfaces/JwtServiceInterface.php
+++ b/src/Interfaces/JwtServiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Interfaces;
 
 use Jose\Component\Core\JWKSet;

--- a/src/Interfaces/OpenIdDiscoveryServiceInterface.php
+++ b/src/Interfaces/OpenIdDiscoveryServiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Interfaces;
 
 interface OpenIdDiscoveryServiceInterface

--- a/src/Interfaces/PushedAuthorizationRequestServiceInterface.php
+++ b/src/Interfaces/PushedAuthorizationRequestServiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Interfaces;
 
 interface PushedAuthorizationRequestServiceInterface

--- a/src/Interfaces/TokenExchangeServiceInterface.php
+++ b/src/Interfaces/TokenExchangeServiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Interfaces;
 
 use Accredifysg\SingPassLogin\DTOs\TokenResponseDto;

--- a/src/Listeners/CorpPassSuccessfulLoginListener.php
+++ b/src/Listeners/CorpPassSuccessfulLoginListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Listeners;
 
 use Accredifysg\SingPassLogin\Events\CorpPassSuccessfulLoginEvent;

--- a/src/Listeners/SingPassSuccessfulLoginListener.php
+++ b/src/Listeners/SingPassSuccessfulLoginListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Listeners;
 
 use Accredifysg\SingPassLogin\Events\SingPassSuccessfulLoginEvent;

--- a/src/Models/CorpPassUser.php
+++ b/src/Models/CorpPassUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Models;
 
 use Accredifysg\SingPassLogin\Exceptions\JwtPayloadException;

--- a/src/Models/SingPassUser.php
+++ b/src/Models/SingPassUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Models;
 
 use Accredifysg\SingPassLogin\Exceptions\JwtPayloadException;

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Models;
 
 use Accredifysg\SingPassLogin\Database\Factories\UserFactory;

--- a/src/Services/CodeChallengeVerifierService.php
+++ b/src/Services/CodeChallengeVerifierService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Services;
 
 use Accredifysg\SingPassLogin\Interfaces\CodeChallengeVerifierServiceInterface;

--- a/src/Services/DPoPService.php
+++ b/src/Services/DPoPService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Services;
 
 use Accredifysg\SingPassLogin\Interfaces\DPoPServiceInterface;

--- a/src/Services/FapiAuthenticationService.php
+++ b/src/Services/FapiAuthenticationService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/src/Services/FapiCallbackService.php
+++ b/src/Services/FapiCallbackService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Services;
 
 use Accredifysg\SingPassLogin\DTOs\FapiCallbackResult;

--- a/src/Services/GetUserInfoService.php
+++ b/src/Services/GetUserInfoService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/src/Services/JwksService.php
+++ b/src/Services/JwksService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/src/Services/JwtService.php
+++ b/src/Services/JwtService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Services;
 
 use Accredifysg\SingPassLogin\Exceptions\JweDecryptionFailedException;

--- a/src/Services/OpenIdDiscoveryService.php
+++ b/src/Services/OpenIdDiscoveryService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/src/Services/PushedAuthorizationRequestService.php
+++ b/src/Services/PushedAuthorizationRequestService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/src/Services/ScopeValidationService.php
+++ b/src/Services/ScopeValidationService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Services;
 
 use InvalidArgumentException;

--- a/src/Services/TokenExchangeService.php
+++ b/src/Services/TokenExchangeService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/src/SingPassLoginServiceProvider.php
+++ b/src/SingPassLoginServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin;
 
 use Accredifysg\SingPassLogin\Events\CorpPassSuccessfulLoginEvent;

--- a/src/Support/SingPassLog.php
+++ b/src/Support/SingPassLog.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Support;
 
 use Illuminate\Support\Facades\Log;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests;
 
 use Accredifysg\SingPassLogin\SingPassLoginServiceProvider;

--- a/tests/Unit/DTOs/OpenIdConfigurationDtoTest.php
+++ b/tests/Unit/DTOs/OpenIdConfigurationDtoTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\DTOs;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/tests/Unit/DTOs/ProviderConfigTest.php
+++ b/tests/Unit/DTOs/ProviderConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\DTOs;
 
 use Accredifysg\SingPassLogin\DTOs\ProviderConfig;

--- a/tests/Unit/Events/CorpPassDataRetrievedEventTest.php
+++ b/tests/Unit/Events/CorpPassDataRetrievedEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Events;
 
 use Accredifysg\SingPassLogin\Events\CorpPassDataRetrievedEvent;

--- a/tests/Unit/Events/CorpPassSuccessfulLoginEventTest.php
+++ b/tests/Unit/Events/CorpPassSuccessfulLoginEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Events;
 
 use Accredifysg\SingPassLogin\Events\CorpPassSuccessfulLoginEvent;

--- a/tests/Unit/Events/SingPassSuccessfulLoginEventTest.php
+++ b/tests/Unit/Events/SingPassSuccessfulLoginEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Events;
 
 use Accredifysg\SingPassLogin\Events\SingPassSuccessfulLoginEvent;

--- a/tests/Unit/Exceptions/JweDecryptionFailedExceptionTest.php
+++ b/tests/Unit/Exceptions/JweDecryptionFailedExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
 use Accredifysg\SingPassLogin\Exceptions\JweDecryptionFailedException;

--- a/tests/Unit/Exceptions/JwksExceptionTest.php
+++ b/tests/Unit/Exceptions/JwksExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
 use Accredifysg\SingPassLogin\Exceptions\JwksException;

--- a/tests/Unit/Exceptions/JwksInvalidExceptionTest.php
+++ b/tests/Unit/Exceptions/JwksInvalidExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
 use Accredifysg\SingPassLogin\Exceptions\JwksInvalidException;

--- a/tests/Unit/Exceptions/JwtDecodeFailedExceptionTest.php
+++ b/tests/Unit/Exceptions/JwtDecodeFailedExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
 use Accredifysg\SingPassLogin\Exceptions\JwtDecodeFailedException;

--- a/tests/Unit/Exceptions/JwtPayloadExceptionTest.php
+++ b/tests/Unit/Exceptions/JwtPayloadExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
 use Accredifysg\SingPassLogin\Exceptions\JwtPayloadException;

--- a/tests/Unit/Exceptions/OpenIdDiscoveryExceptionTest.php
+++ b/tests/Unit/Exceptions/OpenIdDiscoveryExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
 use Accredifysg\SingPassLogin\Exceptions\OpenIdDiscoveryException;

--- a/tests/Unit/Exceptions/SingPassLoginExceptionTest.php
+++ b/tests/Unit/Exceptions/SingPassLoginExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
 use Accredifysg\SingPassLogin\Exceptions\SingPassLoginException;

--- a/tests/Unit/Exceptions/TokenExchangeExceptionTest.php
+++ b/tests/Unit/Exceptions/TokenExchangeExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
 use Accredifysg\SingPassLogin\Exceptions\TokenExchangeException;

--- a/tests/Unit/Exceptions/UserInfoDecryptionExceptionTest.php
+++ b/tests/Unit/Exceptions/UserInfoDecryptionExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
 use Accredifysg\SingPassLogin\Exceptions\UserInfoDecryptionException;

--- a/tests/Unit/Exceptions/UserInfoRequestExceptionTest.php
+++ b/tests/Unit/Exceptions/UserInfoRequestExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
 use Accredifysg\SingPassLogin\Exceptions\UserInfoRequestException;

--- a/tests/Unit/Exceptions/UserInfoVerificationExceptionTest.php
+++ b/tests/Unit/Exceptions/UserInfoVerificationExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
 use Accredifysg\SingPassLogin\Exceptions\UserInfoVerificationException;

--- a/tests/Unit/GetSingPassUserTest.php
+++ b/tests/Unit/GetSingPassUserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit;
 
 use Accredifysg\SingPassLogin\Exceptions\JwtPayloadException;

--- a/tests/Unit/Http/Controllers/CorpPass/LoginCallbackControllerTest.php
+++ b/tests/Unit/Http/Controllers/CorpPass/LoginCallbackControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Http\Controllers\CorpPass;
 
 use Accredifysg\SingPassLogin\DTOs\FapiCallbackResult;

--- a/tests/Unit/Http/Controllers/CorpPass/LoginControllerTest.php
+++ b/tests/Unit/Http/Controllers/CorpPass/LoginControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Http\Controllers\CorpPass;
 
 use Accredifysg\SingPassLogin\Services\FapiAuthenticationService;

--- a/tests/Unit/Http/Controllers/GetJwksEndpointControllerTest.php
+++ b/tests/Unit/Http/Controllers/GetJwksEndpointControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Http\Controllers;
 
 use Accredifysg\SingPassLogin\Exceptions\JwksInvalidException;

--- a/tests/Unit/Http/Controllers/SingPass/LoginCallbackControllerTest.php
+++ b/tests/Unit/Http/Controllers/SingPass/LoginCallbackControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Http\Controllers\SingPass;
 
 use Accredifysg\SingPassLogin\DTOs\FapiCallbackResult;

--- a/tests/Unit/Http/Controllers/SingPass/LoginControllerTest.php
+++ b/tests/Unit/Http/Controllers/SingPass/LoginControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Http\Controllers\SingPass;
 
 use Accredifysg\SingPassLogin\Services\FapiAuthenticationService;

--- a/tests/Unit/Http/Controllers/SingPass/MyInfoCallbackControllerTest.php
+++ b/tests/Unit/Http/Controllers/SingPass/MyInfoCallbackControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Http\Controllers\SingPass;
 
 use Accredifysg\SingPassLogin\DTOs\FapiCallbackResult;

--- a/tests/Unit/Http/Controllers/SingPass/MyInfoControllerTest.php
+++ b/tests/Unit/Http/Controllers/SingPass/MyInfoControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Http\Controllers\SingPass;
 
 use Accredifysg\SingPassLogin\Services\FapiAuthenticationService;

--- a/tests/Unit/Listeners/CorpPassSuccessfulLoginListenerTest.php
+++ b/tests/Unit/Listeners/CorpPassSuccessfulLoginListenerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Listeners;
 
 use Accredifysg\SingPassLogin\Events\CorpPassSuccessfulLoginEvent;

--- a/tests/Unit/Listeners/SingPassSuccessfulLoginListenerTest.php
+++ b/tests/Unit/Listeners/SingPassSuccessfulLoginListenerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Listeners;
 
 use Accredifysg\SingPassLogin\Events\SingPassSuccessfulLoginEvent;

--- a/tests/Unit/Models/CorpPassUserTest.php
+++ b/tests/Unit/Models/CorpPassUserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Models;
 
 use Accredifysg\SingPassLogin\Exceptions\JwtPayloadException;

--- a/tests/Unit/Services/CodeChallengeVerifierServiceTest.php
+++ b/tests/Unit/Services/CodeChallengeVerifierServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services;
 
 use Accredifysg\SingPassLogin\Services\CodeChallengeVerifierService;

--- a/tests/Unit/Services/DPoPServiceTest.php
+++ b/tests/Unit/Services/DPoPServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services;
 
 use Accredifysg\SingPassLogin\Services\DPoPService;

--- a/tests/Unit/Services/FapiAuthenticationServiceTest.php
+++ b/tests/Unit/Services/FapiAuthenticationServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/tests/Unit/Services/FapiCallbackServiceTest.php
+++ b/tests/Unit/Services/FapiCallbackServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services;
 
 use Accredifysg\SingPassLogin\DTOs\FapiCallbackResult;

--- a/tests/Unit/Services/GetUserInfoServiceTest.php
+++ b/tests/Unit/Services/GetUserInfoServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/tests/Unit/Services/JwksServiceTest.php
+++ b/tests/Unit/Services/JwksServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/tests/Unit/Services/OpenIdDiscoveryServiceTest.php
+++ b/tests/Unit/Services/OpenIdDiscoveryServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/tests/Unit/Services/PushedAuthorizationRequestServiceTest.php
+++ b/tests/Unit/Services/PushedAuthorizationRequestServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/tests/Unit/Services/ScopeValidationServiceTest.php
+++ b/tests/Unit/Services/ScopeValidationServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services;
 
 use Accredifysg\SingPassLogin\Services\ScopeValidationService;

--- a/tests/Unit/Services/SingPassJwtService/GenerateClientAssertionTest.php
+++ b/tests/Unit/Services/SingPassJwtService/GenerateClientAssertionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services\SingPassJwtService;
 
 use Accredifysg\SingPassLogin\Exceptions\JwksInvalidException;

--- a/tests/Unit/Services/SingPassJwtService/GetSigningJwkTest.php
+++ b/tests/Unit/Services/SingPassJwtService/GetSigningJwkTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services\SingPassJwtService;
 
 use Accredifysg\SingPassLogin\Exceptions\JwksInvalidException;

--- a/tests/Unit/Services/SingPassJwtService/JweDecryptTest.php
+++ b/tests/Unit/Services/SingPassJwtService/JweDecryptTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services\SingPassJwtService;
 
 use Accredifysg\SingPassLogin\Exceptions\JweDecryptionFailedException;

--- a/tests/Unit/Services/SingPassJwtService/JwtDecodeTest.php
+++ b/tests/Unit/Services/SingPassJwtService/JwtDecodeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services\SingPassJwtService;
 
 use Accredifysg\SingPassLogin\Exceptions\JwtDecodeFailedException;

--- a/tests/Unit/Services/SingPassJwtService/VerifyPayloadTest.php
+++ b/tests/Unit/Services/SingPassJwtService/VerifyPayloadTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services\SingPassJwtService;
 
 use Accredifysg\SingPassLogin\Exceptions\JwtPayloadException;

--- a/tests/Unit/Services/TokenExchangeServiceTest.php
+++ b/tests/Unit/Services/TokenExchangeServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit\Services;
 
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;

--- a/tests/Unit/SingPassLoginServiceProviderTest.php
+++ b/tests/Unit/SingPassLoginServiceProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Accredifysg\SingPassLogin\Tests\Unit;
 
 use Accredifysg\SingPassLogin\Events\SingPassSuccessfulLoginEvent;


### PR DESCRIPTION
## Proposed changes

This pull request introduces a code quality improvement across the codebase by enforcing strict type checking. The `declare(strict_types=1);` directive is added at the top of all PHP files, which helps catch type-related bugs early and ensures better type safety throughout the project.

**Code quality and type safety improvements:**

* Added `declare(strict_types=1);` to all configuration files, including `config/corppass-login.php`, `config/myinfo.php`, `config/ndi.php`, and `config/singpass-login.php`, to enforce strict type checking in configuration logic. [[1]](diffhunk://#diff-98c79ee303925928275ec6d2a58df074f3bb880cc5332895c787422d4a3b7c15R3-R4) [[2]](diffhunk://#diff-6c382dc85eaff1eae542a6b6db60757b1b4ea4ed6baad2a0593f7d91f8b93eb7R3-R4) [[3]](diffhunk://#diff-3493ba376ac113c80ba2b30d75b6c36b379341d620e0ba653c40e23135ff6ba8R3-R4) [[4]](diffhunk://#diff-df93020277ea7849d84de309fee11a343bb4530dac57aef1f5c00943574ecaf8R3-R4)
* Updated all migration and factory files, such as `database/factories/UserFactory.php`, `database/migrations/add_corppass_entity_id_to_users_table.php`, and `database/migrations/add_nric_to_users_table.php`, with strict types declaration. [[1]](diffhunk://#diff-0db00302e9c3c5ad4fd47629fe517d343a414c5667b897b5ae2caa6dc2e37692R3-L7) [[2]](diffhunk://#diff-c9380c09c75090cc4db26dce4c5a5ebe7d4eea22d503978c97a77f8c433c0b42R3-R4) [[3]](diffhunk://#diff-c1169a0ddd3141dea940a95e725e4d57817f2352d847540326806f98449f4a5dR3-R4)
* Applied strict type checking to all DTOs, events, and exception classes in the `src/DTOs`, `src/Events`, and `src/Exceptions` directories (e.g., `FapiCallbackResult.php`, `ProviderConfig.php`, `CorpPassDataRetrievedEvent.php`, `AuthFlowException.php`, etc.). [[1]](diffhunk://#diff-9d74a29d3ebd7f3d45fa6066ac4121055168229f0989b33979b3d6c905d08f3dR3-R4) [[2]](diffhunk://#diff-98477fc9db3bb0ba487b26fa12723a5d3a9f778243a13ed6023c4c78f6d19d08R3-R4) [[3]](diffhunk://#diff-ab554b6a771c0a5e63506a1f64fac3a456fa3ca3a86622200bb8105954e9b42aR3-R4) [[4]](diffhunk://#diff-a3a0175d28e1e0bf18b337dd99646a4ae09cdd10b5248384010968aeda2b36d0R3-R4) [[5]](diffhunk://#diff-04747c975be000dd79026b3269466f0553b24d5abf51321519d3a9e81d05146aR3-R4) [[6]](diffhunk://#diff-98c3352bc9140eca0533acf9c7a3ad6b444e4852cfaa022d58b2da9bcebd9d2eR3-R4) [[7]](diffhunk://#diff-96fdb4efe1e30e0466fb03cb81b009163648ca4d19984389d81ed94c21d6d35eR3-R4) [[8]](diffhunk://#diff-0634241468c071b9d2e569122216c5d5775256fe4f03a08e265070685e3e8dd0R3-R4) [[9]](diffhunk://#diff-b4ce92eacfbb6dceab219d32876169f1afaa328f3f2862891a09174985c677adR3-R4) [[10]](diffhunk://#diff-0bb611364f25496af3194870b42c0fcefeef6a46f73a2a4758a8c1ce9d0ddb66R3-R4) [[11]](diffhunk://#diff-0e59b481c835d29ffd23009ac8564712360acfd261c6eb5e89bdc5b519fef7fbR3-R4) [[12]](diffhunk://#diff-f3ea20fe53bf9ce1027da74d8e7869aee2b5657b9e630c4031f3efffce88229cR3-R4)
* Ensured strict types are enforced in the main routes file, `routes/web.php`.

These changes help improve code reliability and maintainability by making type errors more visible during development and testing.

## Checklist

- [x] Unit/Feature tests passed and maintained at 80% coverage
- [x] Label either `New feature`, `Bugfix`, `Breaking change`, `Refactoring`, `DevOps`, or `Documentation` on GitHub
- [x] I have reviewed the changes myself