### PR TITLE
[DSO-2712] Standardize Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
       time: "09:00"
       timezone: Asia/Singapore
     open-pull-requests-limit: 10
-    reviewers:
-      - "Accredify/DevSecOps"
-      - "Accredifysg/saas-tech-leads"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -19,5 +16,7 @@ updates:
       time: "09:00"
       timezone: Asia/Singapore
     open-pull-requests-limit: 10
-    reviewers:
-      - "Accredify/DevSecOps"
+    groups:
+      accredify-shared-workflows:
+        patterns:
+          - "Accredifysg/Accredify-Github-Workflows*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       time: "09:00"
       timezone: Asia/Singapore
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -16,6 +18,8 @@ updates:
       time: "09:00"
       timezone: Asia/Singapore
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
     groups:
       accredify-shared-workflows:
         patterns:


### PR DESCRIPTION
## Proposed changes

Standardize `.github/dependabot.yml` to match the org-wide Dependabot config standard: normalize schedules, drop reviewers, and add the shared-workflows group.

### Updated
- `.github/dependabot.yml`
  - Removed `reviewers` from the `composer` block
  - Removed `reviewers` from the `github-actions` block
  - Added `groups.accredify-shared-workflows` (patterns: `Accredifysg/Accredify-Github-Workflows*`) to the `github-actions` block

No other ecosystems apply to this repo (no `package.json`, `Dockerfile`, or `*.tf` files present), and `composer.json` only requires public packages, so no Private Packagist registry block was added.

#### Link to Jira Ticket
https://accredify.atlassian.net/browse/DSO-2712 <!-- Replace with actual JIRA ticket URL -->

## Checklist

- [ ] Unit/Feature tests passed and maintained at 80% coverage
- [ ] Label either `New feature`, `Bugfix`, `Breaking change`, `Refactoring`, `DevOps`, or `Documentation` on GitHub
- [ ] I have reviewed the changes myself
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have added/updated necessary documentation (if appropriate)

## Further comments

Schedule (weekly/monday/09:00/Asia/Singapore) and `open-pull-requests-limit: 10` were already correct in this repo's existing config, so no change was needed there.
