### PR TITLE
feat: configurable failure redirect for login/callback errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ php artisan vendor:publish --provider="Accredifysg\SingPassLogin\SingPassLoginSe
 
 ### Shared NDI (`config/ndi.php`)
 
-JWKS, signing keys, DPoP algorithm, and logging — shared across all providers.
+JWKS, signing keys, DPoP algorithm, logging, and failure redirects — shared across all providers.
 
 ```.dotenv
 NDI_SIGNING_KID=
@@ -74,6 +74,10 @@ NDI_DPOP_SIGNING_ALGORITHM=ES256
 
 # Diagnostic logging (disabled by default)
 NDI_LOGS_ENABLED=false
+
+# Where to send the browser when a login/callback fails (see "Failure Redirects").
+# When unset, failures redirect to route('login') with session-flashed errors.
+NDI_FAILURE_REDIRECT_URL=
 ```
 
 ### SingPass Login (`config/singpass-login.php`)
@@ -441,6 +445,22 @@ use Accredifysg\SingPassLogin\Exceptions\UserInfoRequestException;
 use Accredifysg\SingPassLogin\Exceptions\UserInfoDecryptionException;
 use Accredifysg\SingPassLogin\Exceptions\UserInfoVerificationException;
 ```
+
+### Failure Redirects
+
+Login/callback failures that the browser navigates through (`SingPassLoginException`, `CorpPassLoginException`, `AuthFlowException`, `AuthenticationErrorException`) render as a redirect:
+
+- **Default**: `redirect()->route('login')` with a session-flashed error bag (`singpass` or `corppass` key). This requires the host app to define a GET route named `login`. Beware: in a headless API where the `login` route name points at a POST endpoint, the browser's GET lands on a 405 — set the failure redirect URL instead.
+- **With `NDI_FAILURE_REDIRECT_URL` set**: the browser is redirected to that URL with `error` and `error_description` query parameters — suitable for a frontend on a different origin, which cannot read session-flashed errors.
+
+| Exception | `error` |
+| --- | --- |
+| `SingPassLoginException` | `singpass_no_account` |
+| `CorpPassLoginException` | `corppass_no_account` |
+| `AuthFlowException` | `auth_flow_error` |
+| `AuthenticationErrorException` | the provider's OAuth error code (e.g. `access_denied`) |
+
+All other exceptions render JSON responses and are unaffected.
 
 ### Configuration Exceptions
 

--- a/config/ndi.php
+++ b/config/ndi.php
@@ -15,6 +15,13 @@ return [
     // Diagnostic logging (logs PAR, token, UserInfo, JWKS and callback requests)
     'enable_logging' => env('NDI_LOGS_ENABLED', false),
 
+    // Where to send the browser when a login/callback fails. When set, failures
+    // redirect here with `error` and `error_description` query parameters —
+    // suitable for a frontend on another origin. When unset (default), failures
+    // redirect to route('login') with session-flashed errors, which requires the
+    // host app to define a GET route named `login`.
+    'failure_redirect_url' => env('NDI_FAILURE_REDIRECT_URL'),
+
     // JWKS endpoint
     'get_jwks_endpoint_url' => env('NDI_JWKS_URL', '/ndi/jwks'),
     'get_jwks_endpoint_controller' => GetJwksEndpointController::class,

--- a/src/Exceptions/AuthFlowException.php
+++ b/src/Exceptions/AuthFlowException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Accredifysg\SingPassLogin\Exceptions;
 
+use Accredifysg\SingPassLogin\Support\FailureRedirect;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -23,7 +24,7 @@ class AuthFlowException extends HttpException
      */
     public function render(): RedirectResponse
     {
-        return redirect()->route('login')->withErrors(
+        return FailureRedirect::make(
             [
                 'singpass' => [
                     [
@@ -31,7 +32,9 @@ class AuthFlowException extends HttpException
                         'description' => $this->message,
                     ],
                 ],
-            ]
+            ],
+            'auth_flow_error',
+            $this->message,
         );
     }
 }

--- a/src/Exceptions/AuthenticationErrorException.php
+++ b/src/Exceptions/AuthenticationErrorException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Accredifysg\SingPassLogin\Exceptions;
 
+use Accredifysg\SingPassLogin\Support\FailureRedirect;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -42,7 +43,7 @@ class AuthenticationErrorException extends HttpException
 
     public function render(): RedirectResponse
     {
-        return redirect()->route('login')->withErrors(
+        return FailureRedirect::make(
             [
                 'singpass' => [
                     [
@@ -51,7 +52,9 @@ class AuthenticationErrorException extends HttpException
                         'error_code' => $this->errorCode,
                     ],
                 ],
-            ]
+            ],
+            $this->errorCode,
+            $this->errorDescription ?? "An error occurred during authentication: {$this->errorCode}",
         );
     }
 }

--- a/src/Exceptions/CorpPassLoginException.php
+++ b/src/Exceptions/CorpPassLoginException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Accredifysg\SingPassLogin\Exceptions;
 
+use Accredifysg\SingPassLogin\Support\FailureRedirect;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -23,7 +24,7 @@ class CorpPassLoginException extends HttpException
      */
     public function render(): RedirectResponse
     {
-        return redirect()->route('login')->withErrors(
+        return FailureRedirect::make(
             [
                 'corppass' => [
                     [
@@ -31,7 +32,9 @@ class CorpPassLoginException extends HttpException
                         'description' => $this->message,
                     ],
                 ],
-            ]
+            ],
+            'corppass_no_account',
+            $this->message,
         );
     }
 }

--- a/src/Exceptions/SingPassLoginException.php
+++ b/src/Exceptions/SingPassLoginException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Accredifysg\SingPassLogin\Exceptions;
 
+use Accredifysg\SingPassLogin\Support\FailureRedirect;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -23,7 +24,7 @@ class SingPassLoginException extends HttpException
      */
     public function render(): RedirectResponse
     {
-        return redirect()->route('login')->withErrors(
+        return FailureRedirect::make(
             [
                 'singpass' => [
                     [
@@ -31,7 +32,9 @@ class SingPassLoginException extends HttpException
                         'description' => $this->message,
                     ],
                 ],
-            ]
+            ],
+            'singpass_no_account',
+            $this->message,
         );
     }
 }

--- a/src/Support/FailureRedirect.php
+++ b/src/Support/FailureRedirect.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Accredifysg\SingPassLogin\Support;
+
+use Illuminate\Http\RedirectResponse;
+
+final class FailureRedirect
+{
+    /**
+     * Build the redirect response for a failed login/callback.
+     *
+     * When `ndi.failure_redirect_url` is configured, the browser is sent there
+     * with `error` and `error_description` query parameters — suitable for a
+     * frontend on another origin, which cannot read session-flashed errors.
+     *
+     * When it is not configured, this falls back to the legacy behaviour:
+     * `redirect()->route('login')->withErrors($errors)`, which requires the
+     * host app to define a GET route named `login`.
+     *
+     * @param  array<string, mixed>  $errors
+     */
+    public static function make(array $errors, string $errorCode, ?string $errorDescription = null): RedirectResponse
+    {
+        $url = config('ndi.failure_redirect_url');
+
+        if (is_string($url) && $url !== '') {
+            $query = http_build_query(array_filter(
+                [
+                    'error' => $errorCode,
+                    'error_description' => $errorDescription,
+                ],
+                static fn (?string $value): bool => $value !== null && $value !== ''
+            ));
+
+            $separator = str_contains($url, '?') ? '&' : '?';
+
+            return redirect()->away($url.$separator.$query);
+        }
+
+        return redirect()->route('login')->withErrors($errors);
+    }
+}

--- a/tests/Unit/Exceptions/AuthFlowExceptionTest.php
+++ b/tests/Unit/Exceptions/AuthFlowExceptionTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
-use Accredifysg\SingPassLogin\Exceptions\SingPassLoginException;
-use Accredifysg\SingPassLogin\Exceptions\TokenExchangeException;
+use Accredifysg\SingPassLogin\Exceptions\AuthFlowException;
 use Accredifysg\SingPassLogin\Tests\TestCase;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Route;
@@ -13,33 +12,26 @@ use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class SingPassLoginExceptionTest extends TestCase
+class AuthFlowExceptionTest extends TestCase
 {
     public function test_exception_inheritance(): void
     {
-        $exception = new SingPassLoginException;
+        $exception = new AuthFlowException;
         $this->assertInstanceOf(HttpException::class, $exception);
     }
 
     public function test_default_values(): void
     {
-        $exception = new SingPassLoginException;
+        $exception = new AuthFlowException;
         $this->assertEquals(400, $exception->getStatusCode());
-        $this->assertEquals('This SingPass account is not connected with any existing accounts in our system.', $exception->getMessage());
-    }
-
-    public function test_custom_values(): void
-    {
-        $exception = new TokenExchangeException(400, 'Custom message');
-        $this->assertEquals(400, $exception->getStatusCode());
-        $this->assertEquals('Custom message', $exception->getMessage());
+        $this->assertEquals('An error has occurred when processing your request.', $exception->getMessage());
     }
 
     public function test_render(): void
     {
         Route::get('/login')->name('login');
 
-        $exception = new SingPassLoginException;
+        $exception = new AuthFlowException;
 
         $response = $exception->render();
 
@@ -52,8 +44,8 @@ class SingPassLoginExceptionTest extends TestCase
         $this->assertEquals([
             'singpass' => [
                 [
-                    'title' => 'No Account Found',
-                    'description' => 'This SingPass account is not connected with any existing accounts in our system.',
+                    'title' => 'Request Error',
+                    'description' => 'An error has occurred when processing your request.',
                 ],
             ],
         ], $bag->messages());
@@ -63,14 +55,14 @@ class SingPassLoginExceptionTest extends TestCase
     {
         config(['ndi.failure_redirect_url' => 'https://app.example.com/login']);
 
-        $exception = new SingPassLoginException;
+        $exception = new AuthFlowException;
 
         $response = $exception->render();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals(
-            'https://app.example.com/login?error=singpass_no_account&error_description='
-                .urlencode('This SingPass account is not connected with any existing accounts in our system.'),
+            'https://app.example.com/login?error=auth_flow_error&error_description='
+                .urlencode('An error has occurred when processing your request.'),
             $response->getTargetUrl()
         );
     }

--- a/tests/Unit/Exceptions/AuthenticationErrorExceptionTest.php
+++ b/tests/Unit/Exceptions/AuthenticationErrorExceptionTest.php
@@ -96,4 +96,19 @@ class AuthenticationErrorExceptionTest extends TestCase
             ],
         ], $bag->messages());
     }
+
+    public function test_render_redirects_to_configured_failure_url_with_provider_error_code(): void
+    {
+        config(['ndi.failure_redirect_url' => 'https://app.example.com/login']);
+
+        $exception = new AuthenticationErrorException('access_denied', 'Consent was not granted');
+
+        $response = $exception->render();
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame(
+            'https://app.example.com/login?error=access_denied&error_description=Consent+was+not+granted',
+            $response->getTargetUrl()
+        );
+    }
 }

--- a/tests/Unit/Exceptions/CorpPassLoginExceptionTest.php
+++ b/tests/Unit/Exceptions/CorpPassLoginExceptionTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Accredifysg\SingPassLogin\Tests\Unit\Exceptions;
 
-use Accredifysg\SingPassLogin\Exceptions\SingPassLoginException;
-use Accredifysg\SingPassLogin\Exceptions\TokenExchangeException;
+use Accredifysg\SingPassLogin\Exceptions\CorpPassLoginException;
 use Accredifysg\SingPassLogin\Tests\TestCase;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Route;
@@ -13,33 +12,26 @@ use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class SingPassLoginExceptionTest extends TestCase
+class CorpPassLoginExceptionTest extends TestCase
 {
     public function test_exception_inheritance(): void
     {
-        $exception = new SingPassLoginException;
+        $exception = new CorpPassLoginException;
         $this->assertInstanceOf(HttpException::class, $exception);
     }
 
     public function test_default_values(): void
     {
-        $exception = new SingPassLoginException;
+        $exception = new CorpPassLoginException;
         $this->assertEquals(400, $exception->getStatusCode());
-        $this->assertEquals('This SingPass account is not connected with any existing accounts in our system.', $exception->getMessage());
-    }
-
-    public function test_custom_values(): void
-    {
-        $exception = new TokenExchangeException(400, 'Custom message');
-        $this->assertEquals(400, $exception->getStatusCode());
-        $this->assertEquals('Custom message', $exception->getMessage());
+        $this->assertEquals('This CorpPass account is not connected with any existing accounts in our system.', $exception->getMessage());
     }
 
     public function test_render(): void
     {
         Route::get('/login')->name('login');
 
-        $exception = new SingPassLoginException;
+        $exception = new CorpPassLoginException;
 
         $response = $exception->render();
 
@@ -50,10 +42,10 @@ class SingPassLoginExceptionTest extends TestCase
         $bag = $errors->getBag('default');
         $this->assertInstanceOf(MessageBag::class, $bag);
         $this->assertEquals([
-            'singpass' => [
+            'corppass' => [
                 [
                     'title' => 'No Account Found',
-                    'description' => 'This SingPass account is not connected with any existing accounts in our system.',
+                    'description' => 'This CorpPass account is not connected with any existing accounts in our system.',
                 ],
             ],
         ], $bag->messages());
@@ -63,14 +55,14 @@ class SingPassLoginExceptionTest extends TestCase
     {
         config(['ndi.failure_redirect_url' => 'https://app.example.com/login']);
 
-        $exception = new SingPassLoginException;
+        $exception = new CorpPassLoginException;
 
         $response = $exception->render();
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals(
-            'https://app.example.com/login?error=singpass_no_account&error_description='
-                .urlencode('This SingPass account is not connected with any existing accounts in our system.'),
+            'https://app.example.com/login?error=corppass_no_account&error_description='
+                .urlencode('This CorpPass account is not connected with any existing accounts in our system.'),
             $response->getTargetUrl()
         );
     }

--- a/tests/Unit/Support/FailureRedirectTest.php
+++ b/tests/Unit/Support/FailureRedirectTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Accredifysg\SingPassLogin\Tests\Unit\Support;
+
+use Accredifysg\SingPassLogin\Support\FailureRedirect;
+use Accredifysg\SingPassLogin\Tests\TestCase;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
+
+class FailureRedirectTest extends TestCase
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $errors = [
+        'singpass' => [
+            [
+                'title' => 'No Account Found',
+                'description' => 'Account is not connected.',
+            ],
+        ],
+    ];
+
+    public function test_falls_back_to_login_route_with_flashed_errors_when_url_not_configured(): void
+    {
+        config(['ndi.failure_redirect_url' => null]);
+        Route::get('/login')->name('login');
+
+        $response = FailureRedirect::make($this->errors, 'singpass_no_account', 'Account is not connected.');
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame(route('login'), $response->getTargetUrl());
+
+        $errors = session('errors');
+        $this->assertInstanceOf(ViewErrorBag::class, $errors);
+        $bag = $errors->getBag('default');
+        $this->assertInstanceOf(MessageBag::class, $bag);
+        $this->assertSame($this->errors, $bag->messages());
+    }
+
+    public function test_falls_back_to_login_route_when_url_is_empty_string(): void
+    {
+        config(['ndi.failure_redirect_url' => '']);
+        Route::get('/login')->name('login');
+
+        $response = FailureRedirect::make($this->errors, 'singpass_no_account');
+
+        $this->assertSame(route('login'), $response->getTargetUrl());
+    }
+
+    public function test_redirects_to_configured_url_with_error_query_parameters(): void
+    {
+        config(['ndi.failure_redirect_url' => 'https://app.example.com/login']);
+
+        $response = FailureRedirect::make($this->errors, 'singpass_no_account', 'Account is not connected.');
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame(
+            'https://app.example.com/login?error=singpass_no_account&error_description=Account+is+not+connected.',
+            $response->getTargetUrl()
+        );
+    }
+
+    public function test_configured_url_redirect_does_not_flash_session_errors(): void
+    {
+        config(['ndi.failure_redirect_url' => 'https://app.example.com/login']);
+
+        FailureRedirect::make($this->errors, 'singpass_no_account', 'Account is not connected.');
+
+        $this->assertNull(session('errors'));
+    }
+
+    public function test_appends_with_ampersand_when_configured_url_already_has_a_query_string(): void
+    {
+        config(['ndi.failure_redirect_url' => 'https://app.example.com/login?source=singpass']);
+
+        $response = FailureRedirect::make($this->errors, 'auth_flow_error');
+
+        $this->assertSame(
+            'https://app.example.com/login?source=singpass&error=auth_flow_error',
+            $response->getTargetUrl()
+        );
+    }
+
+    public function test_omits_error_description_when_not_provided(): void
+    {
+        config(['ndi.failure_redirect_url' => 'https://app.example.com/login']);
+
+        $response = FailureRedirect::make($this->errors, 'auth_flow_error', null);
+
+        $this->assertSame(
+            'https://app.example.com/login?error=auth_flow_error',
+            $response->getTargetUrl()
+        );
+    }
+}


### PR DESCRIPTION
## Proposed changes

The four exceptions that render browser-facing redirects (`SingPassLoginException`, `CorpPassLoginException`, `AuthFlowException`, `AuthenticationErrorException`) hardcode `redirect()->route('login')->withErrors(...)`. That assumes the host app is a classic Laravel monolith with a GET `login` web route. In a headless API, the route *named* `login` is the POST-only `/api_login`, so every callback failure strands the user's browser on:

```json
{"message": "The GET method is not supported for route api_login. Supported methods: POST."}
```

— and even with a GET login route, a frontend on a different origin can never read the session-flashed error bag.

**Change:** new shared config `ndi.failure_redirect_url` (`NDI_FAILURE_REDIRECT_URL`). When set, failures redirect there with `error` / `error_description` query parameters (handles pre-existing query strings; description omitted when absent; no session flash). The four exceptions delegate to a new `Support\FailureRedirect` helper.

| Exception | `error` |
| --- | --- |
| `SingPassLoginException` | `singpass_no_account` |
| `CorpPassLoginException` | `corppass_no_account` |
| `AuthFlowException` | `auth_flow_error` |
| `AuthenticationErrorException` | provider OAuth error code (e.g. `access_denied`) |

**Backward compatibility:** when the env is unset (default), behaviour is byte-identical to today — `redirect()->route('login')` with the same flashed error bags. All JSON-rendering exceptions are untouched. Suitable for a minor release (v3.1.0).

## Checklist

- [x] Unit/Feature tests passed and maintained at 80% coverage
- [x] Label either `New feature`, `Bugfix`, `Breaking change`, `Refactoring`, `DevOps`, or `Documentation` on GitHub
- [x] I have reviewed the changes myself
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)

## Further comments

Full suite: 313 tests / 767 assertions passing, pint clean, phpstan clean. New `FailureRedirectTest` covers both modes, empty-string config, query-string appending, description omission, and no-session-flash; the two previously untested redirect exceptions (`AuthFlowException`, `CorpPassLoginException`) got test files covering both modes.