### PR TITLE
Refactor: cache OpenID configuration as a plain array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,45 +2,69 @@
 
 ## v4.0.0
 
-Maintenance release, with three changes:
+Maintenance release with three changes:
 
-- **Laravel 10 support is dropped.**
-- **CI matrix testing is introduced**, covering every supported PHP and Laravel combination.
-- **The OpenID configuration is now cached as a plain array**, as groundwork for Laravel 13.
+- Laravel 10 support is removed.
+- A CI test matrix is added. It does tests of each supported PHP and Laravel combination.
+- The OpenID configuration is now cached as a plain array. This prepares the package for Laravel 13.
 
-Laravel 13 support is not part of this release; it follows separately.
+Notes:
 
-The version bump is a major one because Laravel 10 is dropped. Projects already on v3.x continue to resolve as before; only those that explicitly upgrade to v4 pick up the narrowed constraints below.
+- Laravel 13 support is not part of this release. It comes in a later release.
+- The version increase is major because Laravel 10 support is removed.
+- Projects on v3.x resolve as before. Only an explicit upgrade to v4 gets the new constraints.
 
-### OpenID configuration is now cached as a plain array
+### OpenID configuration cached as a plain array
 
-The OpenID discovery configuration is now stored in the cache as a plain array instead of a serialized `OpenIdConfigurationDto` object. This is groundwork for Laravel 13, whose [`cache.serializable_classes` configuration](https://laravel.com/docs/13.x/upgrade#cache-serializable_classes-configuration) restricts which classes the cache will deserialize — with a plain array payload, applications never need to add this package's DTO to their allowlist. (Laravel 13 support itself follows in a separate release.)
+- The cache now holds the OpenID discovery configuration as a plain array, not a serialized DTO.
+- Laravel 13 [`cache.serializable_classes`][l13] restricts the classes that the cache can deserialize.
+- With a plain array, applications do not add this package's DTO to their allowlist.
+- Reads use the new `OpenIdConfigurationDto::fromCache()` method:
+    - It validates the array with the same rules as the discovery response.
+    - It returns `null` for data that is not usable.
+- **The discovery writer is self-healing:**
+    - `cacheOpenIdDiscovery()` discards a cache entry that it cannot read back. It then does discovery again.
+    - It does not keep a bad entry until the TTL expires.
+    - Examples of bad entries: a serialized DTO from a previous version, an entry that an allowlist rejects.
 
-Reads go through the new `OpenIdConfigurationDto::fromCache()`, which rehydrates the array via the same validation as the discovery response and returns `null` for anything unusable.
-
-**The discovery writer is now self-healing.** If the cache holds an entry that cannot be read back — a serialized DTO written by a previous version of this package, an entry rejected by a `serializable_classes` allowlist, or any other stale shape — `cacheOpenIdDiscovery()` discards it and re-runs discovery instead of keeping it until the TTL expires.
+[l13]: https://laravel.com/docs/13.x/upgrade#cache-serializable_classes-configuration
 
 ### Upgrade notes
 
-- **No action required for the cache transition.** Entries written by the previous version are discarded and refreshed automatically the next time an authentication flow runs discovery.
-- **If you read the OpenID cache key directly**, note the payload is now an array whose keys match the discovery response (`issuer`, `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `jwks_uri`, `pushed_authorization_request_endpoint`), not a DTO instance. Rehydrate with `OpenIdConfigurationDto::fromCache()` if you want the object.
+- No action is necessary for the cache transition.
+- The next authentication flow that does discovery discards and refreshes the old entries automatically.
+- If you read the OpenID cache key directly: the payload is now an array, not a DTO instance.
+- The array keys are the same as the keys of the discovery response:
+    - `issuer`, `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `jwks_uri`
+    - `pushed_authorization_request_endpoint`
+- To get the object, use `OpenIdConfigurationDto::fromCache()`.
 
-### Laravel 10 dropped
+### Laravel 10 support removed
 
-**Illuminate constraints changed** from `^10.0||^11.0||^12.0` to `^11.3||^12.0`. The bound was narrowed so it describes what actually works:
-
-- **Laravel 10** was not installable. `web-token/jwt-framework ^4.0` requires Symfony 7 while Laravel 10 pins Symfony 6 — an unresolvable conflict. Applications on Laravel 10 previously got a confusing transitive Symfony error; they now get a clear refusal naming the real requirement.
-- **Laravel 11.0 – 11.2** lack `Http::createPendingRequest()`, which was added in Laravel 11.3 and is used for JWKS retrieval and OpenID discovery. Those versions previously installed and then failed at runtime on the first JWKS fetch; Composer now rejects them at install time.
+- The Illuminate constraints changed from `^10.0||^11.0||^12.0` to `^11.3||^12.0`.
+- The narrower bound describes the versions that operate correctly.
+- **Laravel 10** was not installable:
+    - `web-token/jwt-framework ^4.0` needs Symfony 7, but Laravel 10 pins Symfony 6. No solution exists.
+    - Before, applications on Laravel 10 got an unclear transitive Symfony error.
+    - Now, Composer refuses with a message that gives the real requirement.
+- **Laravel 11.0 – 11.2** do not have `Http::createPendingRequest()`:
+    - Laravel 11.3 added this method. The package uses it for JWKS retrieval and OpenID discovery.
+    - Before, these versions installed, then failed at runtime on the first JWKS fetch.
+    - Now, Composer rejects them at installation time.
 
 ### CI matrix testing
 
-Added `Run Tests` workflow covering PHP 8.2 – 8.5 against Laravel 11 and 12, resolved with `--prefer-stable`. It is a reusable workflow called from `feature.yml` and `merge_to_master.yml`, running in parallel with `ci` so it stays off the critical path. The coverage badge now waits on the matrix as well as `ci`, so a committed badge always reflects a commit that passed every leg.
-
-See [`docs/ci-test-matrix.md`](docs/ci-test-matrix.md) for the full matrix, the reasoning behind each exclusion, the advisory policy and how to reproduce a leg locally.
+- A new `Run Tests` workflow does tests of PHP 8.2 – 8.5 with Laravel 11 and 12, resolved with `--prefer-stable`.
+- It is a reusable workflow. `feature.yml` and `merge_to_master.yml` start it.
+- It runs in parallel with `ci`. Thus it does not increase the critical path.
+- The coverage badge waits for `ci` and the matrix. Thus the badge shows a commit that passed each leg.
+- Refer to [`docs/ci-test-matrix.md`](docs/ci-test-matrix.md) for the matrix, the exclusions, and the advisory policy.
 
 ### composer.json tidy-up
 
-**Illuminate packages now declared explicitly.** Previously only `illuminate/contracts` was declared, covering 2 of the package's 67 Illuminate imports — the rest resolved implicitly because `laravel/framework` replaces that package. Added:
+- **The Illuminate packages are now declared explicitly:**
+    - Before, only `illuminate/contracts` was declared. It covered 2 of the 67 Illuminate imports.
+    - The other imports resolved implicitly, because `laravel/framework` replaces the Illuminate packages.
 
 | Package | Covers |
 |---|---|
@@ -49,9 +73,13 @@ See [`docs/ci-test-matrix.md`](docs/ci-test-matrix.md) for the full matrix, the 
 | `illuminate/routing` | `Controller` |
 | `illuminate/support` | `ServiceProvider`, `Str`, and the `Http`/`Cache`/`Log`/`Event`/`Auth` facades |
 
-No behavioural change — `laravel/framework` satisfies all of them. `Illuminate\Foundation\Auth\User` (used by `Models\User`) stays implicit, as it ships only inside `laravel/framework` and has no installable standalone package.
-
-**`minimum-stability` set to `dev` with `prefer-stable`**, matching the convention across the Laravel package ecosystems. Stable releases are always preferred; dev branches enter the pool only when no stable candidate remains. This is also what lets the Laravel 11 matrix legs resolve at all, given the advisory situation described above.
+- There is no change in behavior — `laravel/framework` satisfies all of them.
+- `Illuminate\Foundation\Auth\User` (used by `Models\User`) stays implicit.
+- It ships only in `laravel/framework`. No standalone package contains it.
+- **`minimum-stability` is set to `dev`, with `prefer-stable: true`:**
+    - This agrees with the convention in the Laravel package ecosystem.
+    - The resolver always prefers stable releases. Dev branches apply only when no stable candidate stays.
+    - This also lets the Laravel 11 matrix legs resolve (refer to `docs/ci-test-matrix.md`).
 
 ## v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,28 @@
 
 ## v4.0.0
 
-Maintenance release, with two changes:
+Maintenance release, with three changes:
 
 - **Laravel 10 support is dropped.**
 - **CI matrix testing is introduced**, covering every supported PHP and Laravel combination.
+- **The OpenID configuration is now cached as a plain array**, as groundwork for Laravel 13.
 
-There are no functional changes to the package — `src/` is untouched. Laravel 13 support is not part of this release; it follows separately.
+Laravel 13 support is not part of this release; it follows separately.
 
 The version bump is a major one because Laravel 10 is dropped. Projects already on v3.x continue to resolve as before; only those that explicitly upgrade to v4 pick up the narrowed constraints below.
+
+### OpenID configuration is now cached as a plain array
+
+The OpenID discovery configuration is now stored in the cache as a plain array instead of a serialized `OpenIdConfigurationDto` object. This is groundwork for Laravel 13, whose [`cache.serializable_classes` configuration](https://laravel.com/docs/13.x/upgrade#cache-serializable_classes-configuration) restricts which classes the cache will deserialize — with a plain array payload, applications never need to add this package's DTO to their allowlist. (Laravel 13 support itself follows in a separate release.)
+
+Reads go through the new `OpenIdConfigurationDto::fromCache()`, which rehydrates the array via the same validation as the discovery response and returns `null` for anything unusable.
+
+**The discovery writer is now self-healing.** If the cache holds an entry that cannot be read back — a serialized DTO written by a previous version of this package, an entry rejected by a `serializable_classes` allowlist, or any other stale shape — `cacheOpenIdDiscovery()` discards it and re-runs discovery instead of keeping it until the TTL expires.
+
+### Upgrade notes
+
+- **No action required for the cache transition.** Entries written by the previous version are discarded and refreshed automatically the next time an authentication flow runs discovery.
+- **If you read the OpenID cache key directly**, note the payload is now an array whose keys match the discovery response (`issuer`, `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `jwks_uri`, `pushed_authorization_request_endpoint`), not a DTO instance. Rehydrate with `OpenIdConfigurationDto::fromCache()` if you want the object.
 
 ### Laravel 10 dropped
 

--- a/docs/ci-test-matrix.md
+++ b/docs/ci-test-matrix.md
@@ -1,133 +1,96 @@
 # CI test matrix
 
-This package is tested across every supported PHP and Laravel combination by the
-`Run Tests` workflow (`.github/workflows/run-test.yml`). This document explains what
-the matrix covers, why each exclusion exists, and the known limitation around
-Laravel 11.
+The `Run Tests` workflow (`.github/workflows/run-test.yml`) does tests of this package on each supported combination of
+PHP and Laravel.
 
 ## Coverage
 
-Two axes — PHP version and Laravel version — producing **7 legs**:
+Two axes (PHP version, Laravel version) make **7 legs**:
 
-|  | PHP 8.2 | PHP 8.3 | PHP 8.4 | PHP 8.5 |
-|---|---|---|---|---|
-| **Laravel 11** (testbench 9) | ✅ | ✅ | ✅ | excluded |
-| **Laravel 12** (testbench 10) | ✅ | ✅ | ✅ | ✅ |
+|                               | PHP 8.2 | PHP 8.3 | PHP 8.4 | PHP 8.5  |
+|-------------------------------|---------|---------|---------|----------|
+| **Laravel 11** (testbench 9)  | ✅       | ✅       | ✅       | excluded |
+| **Laravel 12** (testbench 10) | ✅       | ✅       | ✅       | ✅        |
 
-Every leg resolves with a single `dependency-version`, `prefer-stable`.
+- Each leg resolves with one `dependency-version` value: `prefer-stable`.
+- The one exclusion (**PHP 8.5 × Laravel 11**) is a hard constraint: Laravel 11 does not operate on PHP 8.5.
 
-The one exclusion is a hard constraint rather than a preference: **PHP 8.5 × Laravel
-11** — Laravel 11 predates PHP 8.5 and was never supported on it.
+## Workflow structure
 
-## How the matrix is wired
-
-`run-test.yml` is a `workflow_call` workflow, not a standalone one. It is invoked from
-both entry points:
-
-- `feature.yml` — pull requests and pushes to master
-- `merge_to_master.yml` — pushes to master
-
-The matrix runs **in parallel with `ci`**, not behind it. The seven legs together take
-around 90 seconds while `ci` takes closer to two and a half minutes, so running them
-concurrently hides the matrix inside `ci`'s runtime instead of adding to the critical
-path — roughly a third off the total wall clock. The trade is that a failing `ci` still
-spends the matrix runners.
-
-In `feature.yml` the `badge` job needs `[ci, matrix]`, so a committed coverage badge
-only ever reflects a commit that passed every leg. That ordering is what the dependency
-is for; gating the matrix itself on `ci` is not needed to get it.
-
-Note that `feature.yml` and `merge_to_master.yml` both trigger on pushes to master, so
-`ci` and the matrix each run twice on a master push. That duplication predates the
-matrix and is left alone deliberately.
+- `run-test.yml` is a `workflow_call` workflow, not a standalone workflow.
+- Two workflows start it:
+    - `feature.yml` — pull requests and pushes to master
+    - `merge_to_master.yml` — pushes to master
 
 ## Resolution strategy
 
-The matrix runs `prefer-stable` only, which answers "does the package work against
-current releases?" The floors of the declared constraints are therefore **not**
-exercised in CI — a floor such as `illuminate/support: ^11.3` or
-`web-token/jwt-framework: ^4.0.2` is an argued claim, not a tested one. If you change a
-floor, reason about it explicitly or resolve it by hand (see
-[Reproducing a leg locally](#reproducing-a-leg-locally)).
+- The matrix uses `prefer-stable` only. This does a test with the current releases.
+- CI does **not** do tests of the constraint floors.
+- A floor such as `illuminate/support: ^11.3` or `web-token/jwt-framework: ^4.0.2` is a claim without a test.
+- If you change a floor, examine the effect, or do a [local test](#do-a-test-of-one-leg-locally).
+- Example of the gap — the `jwt-framework` floor:
+    - The declared constraint was `^4.0.1`.
+    - Version 4.0.1 refers to `RangeException` without a namespace in `Jose\Component\Core\Util`.
+    - Thus PHP causes a fatal `Error`, not an exception.
+    - The `catch (Exception)` in `generateClientAssertion()` did not catch it. `GenerateClientAssertionTest` failed.
+    - Each `prefer-stable` leg stayed green. Only a lowest-resolution run found the defect.
+    - The floor is now `^4.0.2`, the first release that has the import.
 
-That gap is worth stating plainly, because the current `jwt-framework` floor exists
-precisely because a lowest-resolution run once caught something. `web-token/jwt-framework`
-was declared as `^4.0.1`, and 4.0.1 references `RangeException` unqualified inside
-`Jose\Component\Core\Util`, so PHP resolves it to the non-existent
-`Jose\Component\Core\Util\RangeException` and raises a fatal `Error` instead of an
-exception. That `Error` is not an `Exception`, so it slipped past the `catch (Exception)`
-in `JwtService::generateClientAssertion()` and broke `GenerateClientAssertionTest`. Every
-`prefer-stable` leg was green throughout. The floor is now `^4.0.2`, the first upstream
-release carrying the import.
-
-## How each leg resolves dependencies
+## How dependency is resolved for each leg
 
 ```yaml
-composer require --dev --no-update --no-interaction \
-  "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}"
+composer require --dev --no-update --no-interaction "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}"
 composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress
 ```
 
-The committed `composer.lock` is deliberately bypassed. Installing the lock would test one
-pinned tree 7 times; resolving fresh exercises the constraints that are actually published
-to consumers.
+- The workflow does not use the committed `composer.lock`.
+- The first command writes a new `composer.json` in the runner.
+- Thus each leg replaces the `orchestra/testbench` constraint, and CI does not do a test of it.
+- The `require` constraints and the other `require-dev` entries stay applicable.
+- PHPUnit gets `--no-coverage` because `phpunit.xml` declares a clover report and the matrix has `coverage: none`.
+- Without the flag, PHPUnit stops with a non-zero code.
+- `ci.yml` keeps the ownership of coverage (Xdebug).
 
-Because that first command rewrites `composer.json` in the runner, the `orchestra/testbench`
-constraint declared in the repository is overridden per leg and is not what CI tests. The
-`require` constraints and the remaining `require-dev` entries do still apply.
+## Relation to `ci.yml`
 
-`--no-coverage` is passed to PHPUnit because `phpunit.xml` declares a clover report and the
-matrix runs with `coverage: none`. Without the flag there is no driver to satisfy the report
-and PHPUnit exits non-zero on that runner warning. Coverage stays owned by `ci.yml`, which
-runs with Xdebug.
-
-## Relationship to `ci.yml`
-
-`ci.yml` owns the coverage gate, the Pint auto-commit and the Sonar scan, and runs a single
-tree: PHP 8.3 against the committed `composer.lock`. The matrix runs fresh resolutions across
-PHP and Laravel versions. Neither implies the other — a green `ci` does not predict a green
-matrix, and vice versa.
-
-Keeping the two separate also avoids two concrete problems:
-
-1. Matrix jobs cannot produce a reliable workflow output, and `ci.yml` exports `coverage`
-   to `badge.yml`.
-2. Multiple legs would race on `git-auto-commit-action`.
+- `ci.yml`: coverage gate, automatic Pint commit, Sonar scan. One tree — PHP 8.3 with the committed `composer.lock`.
+- The matrix: new resolutions across the PHP and Laravel versions.
+- The two results are independent: a green `ci` does not show a green matrix, and the opposite is also true.
+- The two stay separate to prevent two problems:
+    1. Matrix jobs cannot supply a reliable workflow output; `ci.yml` sends `coverage` to `badge.yml`.
+    2. More than one leg on `git-auto-commit-action` causes a race condition.
+- Future considerations to refactor the two.
 
 ## Security advisory policy
 
-No advisory suppression is configured in this repository — there is no
-`policy.advisories.block`, no `ignore-id`, and no `audit.ignore`. Composer's default
-policy therefore applies.
+- This repository has no advisory suppression (`policy.advisories.block`, `ignore-id`, `audit.ignore`).
+- Thus the default Composer policy is applicable.
+- From Composer 2.10, the **resolver** applies this policy, not an audit after the installation:
+    - The resolver removes each version that has a known advisory from the candidate pool.
+- Thus a leg can degrade or fail at resolution — this is different from a test failure:
+    - If a clean tagged version stays in the range, the resolver installs it. This is the usual result.
+    - If not, `minimum-stability: dev` lets the resolver use a matching dev branch (refer to the Laravel 11 section).
+    - If no matching branch exists, the resolution fails. Consumer projects have no dev fallback and fail at once.
+- Correction: increase the floor in `composer.json`. Do not suppress the advisory.
 
-Since Composer 2.10 that policy is enforced **in the resolver**, not as a post-install
-audit: versions affected by a known advisory are removed from the candidate pool entirely,
-and resolution fails if nothing clean remains in range. The practical consequence for this
-matrix is that a leg can fail to *resolve* — distinct from failing tests — when a
-dependency's range is fully covered by advisories. Fix that by raising the floor in
-`composer.json`, not by suppressing the advisory.
+## Known limitation: the tests do not include a released Laravel 11 version
 
-## Known limitation: Laravel 11 is not covered against a released version
+- The security support for Laravel 11 stopped in March 2026.
+- Seven security advisories remove each tagged 11.x release. Three will not get a corrected version.
+- Composer will not install one of these releases.
+- Thus the Laravel 11 legs resolve the untagged `11.x-dev` branch tip. An application cannot install this code.
+- The CI logs show this: `Installing laravel/framework (11.x-dev c0f062f)`.
+- **A green Laravel 11 leg is not verification of a Laravel 11 release that an application can install.**
+- The Laravel 12 legs give the important coverage.
+- This is the only reason for the `composer.json` pair `minimum-stability: dev` and `prefer-stable: true`:
+    - `minimum-stability: dev` permits the fallback to `11.x-dev`. Without it, the Laravel 11 resolution fails.
+    - `prefer-stable: true` keeps the other dependencies on tagged releases. The dev stability does not spread.
+- An application that must use Laravel 11 must permit those advisories in its own Composer configuration.
 
-Laravel 11 left security support in Mar 2026, and every tagged 11.x release is excluded by
-seven security advisories — three of which will never have a fixed version. Under the
-default policy above, Composer will not install any of them.
+## Doing a test of one leg locally
 
-The Laravel 11 legs therefore resolve the untagged `11.x-dev` branch tip (verified in CI
-logs: `Installing laravel/framework (11.x-dev c0f062f)`), which is unreleased code no
-application can install. **A green Laravel 11 leg is not verification of an installable
-Laravel 11 release.** The Laravel 12 legs resolve real tagged releases and are the
-meaningful coverage.
-
-This is also the only reason `minimum-stability: dev` matters to the matrix: without it the
-Laravel 11 legs fail to resolve outright rather than falling back to the branch tip.
-
-Applications wanting to install this package on Laravel 11 will need to allow those
-advisories in their own Composer configuration.
-
-## Reproducing a leg locally
-
-Work on a scratch clone — this overwrites `composer.json` and `composer.lock`:
+Do this if you wish to test locally for a specific laravel version.
+Use a temporary clone. This procedure writes new `composer.json` and `composer.lock` files.
 
 ```bash
 composer require --dev --no-update "laravel/framework:12.*" "orchestra/testbench:10.*"
@@ -135,10 +98,8 @@ composer update --prefer-stable --prefer-dist
 vendor/bin/phpunit --no-coverage
 ```
 
-Change the two version constraints to match whichever leg you are chasing. The `testbench`
-version must be paired correctly: Laravel 11 → testbench 9, Laravel 12 → testbench 10.
-
-Swapping in `--prefer-lowest` is how you check a constraint floor by hand, since no CI leg
-covers that. Expect to reason about the result: `prefer-lowest` resolves the lowest
-*mutually compatible* set rather than the literal floor of every constraint, so the version
-installed varies per leg.
+- Change the two version constraints to the values of the applicable leg.
+- Use the correct pair: Laravel 11 → testbench 9, Laravel 12 → testbench 10.
+- To do a test of a constraint floor, use `--prefer-lowest`. No CI leg does this test.
+- Note: `prefer-lowest` resolves the lowest set of compatible versions, not the literal floor of each constraint.
+- Thus the installed versions are different for each leg.

--- a/src/DTOs/OpenIdConfigurationDto.php
+++ b/src/DTOs/OpenIdConfigurationDto.php
@@ -71,4 +71,40 @@ readonly class OpenIdConfigurationDto
                 ?? throw new OpenIdDiscoveryException(500, 'OpenID discovery response has invalid non-string field: pushed_authorization_request_endpoint'),
         );
     }
+
+    /**
+     * Flatten to a plain array for caching. Keys match the discovery response so
+     * the payload can be fed straight back through fromDiscoveryResponse().
+     *
+     * @return array{issuer: string, authorization_endpoint: string, token_endpoint: string, userinfo_endpoint: string, jwks_uri: string, pushed_authorization_request_endpoint: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'issuer' => $this->issuer,
+            'authorization_endpoint' => $this->authorizationEndpoint,
+            'token_endpoint' => $this->tokenEndpoint,
+            'userinfo_endpoint' => $this->userinfoEndpoint,
+            'jwks_uri' => $this->jwksUri,
+            'pushed_authorization_request_endpoint' => $this->pushedAuthorizationRequestEndpoint,
+        ];
+    }
+
+    /**
+     * Rehydrate from a cached payload, returning null for anything unusable — a
+     * miss, a stale shape, or a value left by an older version of the package.
+     * Callers throw their own service-specific exception on null.
+     */
+    public static function fromCache(mixed $cached): ?self
+    {
+        if (! is_array($cached)) {
+            return null;
+        }
+
+        try {
+            return self::fromDiscoveryResponse((object) $cached);
+        } catch (OpenIdDiscoveryException) {
+            return null;
+        }
+    }
 }

--- a/src/Services/FapiAuthenticationService.php
+++ b/src/Services/FapiAuthenticationService.php
@@ -62,9 +62,9 @@ class FapiAuthenticationService
 
         $dpopKey = $this->dpopService->generateKeyPair();
 
-        $openIdConfig = Cache::get($config->cacheKey);
+        $openIdConfig = OpenIdConfigurationDto::fromCache(Cache::get($config->cacheKey));
 
-        if (! $openIdConfig instanceof OpenIdConfigurationDto) {
+        if ($openIdConfig === null) {
             throw new AuthFlowException(500, 'OpenID configuration not found in cache');
         }
 

--- a/src/Services/GetUserInfoService.php
+++ b/src/Services/GetUserInfoService.php
@@ -82,9 +82,9 @@ final readonly class GetUserInfoService implements GetUserInfoServiceInterface
      */
     public function getUserInfo(string $accessToken, JWK $dpopKey, string $cacheKey): array
     {
-        $openIdConfig = Cache::get($cacheKey);
+        $openIdConfig = OpenIdConfigurationDto::fromCache(Cache::get($cacheKey));
 
-        if (! $openIdConfig instanceof OpenIdConfigurationDto) {
+        if ($openIdConfig === null) {
             throw new UserInfoRequestException(500, 'OpenID configuration not found in cache');
         }
 

--- a/src/Services/JwksService.php
+++ b/src/Services/JwksService.php
@@ -20,9 +20,9 @@ final class JwksService implements JwksServiceInterface
      */
     public function getJwks(string $cacheKey): JWKSet
     {
-        $openIdConfig = Cache::get($cacheKey);
+        $openIdConfig = OpenIdConfigurationDto::fromCache(Cache::get($cacheKey));
 
-        if (! $openIdConfig instanceof OpenIdConfigurationDto) {
+        if ($openIdConfig === null) {
             throw new JwksException(500, 'OpenID configuration not found in cache');
         }
 

--- a/src/Services/OpenIdDiscoveryService.php
+++ b/src/Services/OpenIdDiscoveryService.php
@@ -21,16 +21,7 @@ final class OpenIdDiscoveryService implements OpenIdDiscoveryServiceInterface
      */
     public function cacheOpenIdDiscovery(string $discoveryEndpoint, string $cacheKey): void
     {
-        // An unusable entry — a serialized DTO written by an older version of the
-        // package, or any other stale shape — would otherwise be kept by
-        // Cache::remember until its TTL expires, failing every read in the meantime.
-        $existing = Cache::get($cacheKey);
-
-        if ($existing !== null && OpenIdConfigurationDto::fromCache($existing) === null) {
-            SingPassLog::info('Discarding unusable cached OpenID configuration', ['cache_key' => $cacheKey]);
-
-            Cache::forget($cacheKey);
-        }
+        $this->forgetUnusableCacheEntry($cacheKey);
 
         Cache::remember($cacheKey, now()->addHour(), static function () use ($discoveryEndpoint) {
             SingPassLog::info('OpenID Discovery request', ['endpoint' => $discoveryEndpoint]);
@@ -72,5 +63,24 @@ final class OpenIdDiscoveryService implements OpenIdDiscoveryServiceInterface
 
             return OpenIdConfigurationDto::fromDiscoveryResponse($decoded)->toArray();
         });
+    }
+
+    /**
+     * Drop a cached entry that cannot be read back — a serialized DTO written by
+     * an older version of the package, or any other stale shape. Left in place,
+     * Cache::remember would keep returning it until its TTL expired, failing
+     * every read in the meantime.
+     */
+    private function forgetUnusableCacheEntry(string $cacheKey): void
+    {
+        $existing = Cache::get($cacheKey);
+
+        if ($existing === null || OpenIdConfigurationDto::fromCache($existing) !== null) {
+            return;
+        }
+
+        SingPassLog::info('Discarding unusable cached OpenID configuration', ['cache_key' => $cacheKey]);
+
+        Cache::forget($cacheKey);
     }
 }

--- a/src/Services/OpenIdDiscoveryService.php
+++ b/src/Services/OpenIdDiscoveryService.php
@@ -21,6 +21,17 @@ final class OpenIdDiscoveryService implements OpenIdDiscoveryServiceInterface
      */
     public function cacheOpenIdDiscovery(string $discoveryEndpoint, string $cacheKey): void
     {
+        // An unusable entry — a serialized DTO written by an older version of the
+        // package, or any other stale shape — would otherwise be kept by
+        // Cache::remember until its TTL expires, failing every read in the meantime.
+        $existing = Cache::get($cacheKey);
+
+        if ($existing !== null && OpenIdConfigurationDto::fromCache($existing) === null) {
+            SingPassLog::info('Discarding unusable cached OpenID configuration', ['cache_key' => $cacheKey]);
+
+            Cache::forget($cacheKey);
+        }
+
         Cache::remember($cacheKey, now()->addHour(), static function () use ($discoveryEndpoint) {
             SingPassLog::info('OpenID Discovery request', ['endpoint' => $discoveryEndpoint]);
 
@@ -59,7 +70,7 @@ final class OpenIdDiscoveryService implements OpenIdDiscoveryServiceInterface
                 'par_endpoint' => $parEndpoint,
             ]);
 
-            return OpenIdConfigurationDto::fromDiscoveryResponse($decoded);
+            return OpenIdConfigurationDto::fromDiscoveryResponse($decoded)->toArray();
         });
     }
 }

--- a/src/Services/PushedAuthorizationRequestService.php
+++ b/src/Services/PushedAuthorizationRequestService.php
@@ -23,9 +23,9 @@ final class PushedAuthorizationRequestService implements PushedAuthorizationRequ
      */
     public function sendRequest(array $params, string $dpopProofJwt, string $cacheKey): string
     {
-        $openIdConfig = Cache::get($cacheKey);
+        $openIdConfig = OpenIdConfigurationDto::fromCache(Cache::get($cacheKey));
 
-        if (! $openIdConfig instanceof OpenIdConfigurationDto) {
+        if ($openIdConfig === null) {
             throw new PushedAuthorizationRequestException(
                 statusCode: 500,
                 message: 'OpenID configuration not found in cache',

--- a/src/Services/TokenExchangeService.php
+++ b/src/Services/TokenExchangeService.php
@@ -32,9 +32,9 @@ final class TokenExchangeService implements TokenExchangeServiceInterface
     {
         $jwk = JwtService::getSigningJwk();
 
-        $openIdConfig = Cache::get($cacheKey);
+        $openIdConfig = OpenIdConfigurationDto::fromCache(Cache::get($cacheKey));
 
-        if (! $openIdConfig instanceof OpenIdConfigurationDto) {
+        if ($openIdConfig === null) {
             throw new TokenExchangeException(500, 'OpenID configuration not found in cache');
         }
 

--- a/tests/Unit/Services/FapiAuthenticationServiceTest.php
+++ b/tests/Unit/Services/FapiAuthenticationServiceTest.php
@@ -67,14 +67,14 @@ class FapiAuthenticationServiceTest extends TestCase
 
     private function seedCache(string $cacheKey = 'openId:test'): void
     {
-        Cache::put($cacheKey, new OpenIdConfigurationDto(
+        Cache::put($cacheKey, (new OpenIdConfigurationDto(
             issuer: 'https://example.com',
             authorizationEndpoint: 'https://example.com/auth',
             tokenEndpoint: 'https://example.com/token',
             userinfoEndpoint: 'https://example.com/userinfo',
             jwksUri: 'https://example.com/jwks',
             pushedAuthorizationRequestEndpoint: 'https://example.com/par',
-        ));
+        ))->toArray());
     }
 
     public function test_initiate_auth_returns_redirect_url(): void

--- a/tests/Unit/Services/GetUserInfoServiceTest.php
+++ b/tests/Unit/Services/GetUserInfoServiceTest.php
@@ -60,14 +60,14 @@ class GetUserInfoServiceTest extends TestCase
 
         $this->dpopKey = JWKFactory::createECKey('P-256');
 
-        Cache::put('openId', new OpenIdConfigurationDto(
+        Cache::put('openId', (new OpenIdConfigurationDto(
             issuer: 'https://example.com',
             authorizationEndpoint: 'https://example.com/auth',
             tokenEndpoint: 'https://example.com/token',
             userinfoEndpoint: 'https://example.com/userinfo',
             jwksUri: 'https://example.com/jwks',
             pushedAuthorizationRequestEndpoint: 'https://example.com/par',
-        ));
+        ))->toArray());
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Services/JwksServiceTest.php
+++ b/tests/Unit/Services/JwksServiceTest.php
@@ -7,6 +7,7 @@ namespace Accredifysg\SingPassLogin\Tests\Unit\Services;
 use Accredifysg\SingPassLogin\DTOs\OpenIdConfigurationDto;
 use Accredifysg\SingPassLogin\Exceptions\JwksException;
 use Accredifysg\SingPassLogin\Services\JwksService;
+use Accredifysg\SingPassLogin\Services\OpenIdDiscoveryService;
 use Accredifysg\SingPassLogin\Tests\TestCase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -18,14 +19,54 @@ class JwksServiceTest extends TestCase
     {
         parent::setUp();
         // Set up the cache with a mock OpenId configuration
-        Cache::put('openId', new OpenIdConfigurationDto(
+        Cache::put('openId', (new OpenIdConfigurationDto(
             issuer: 'https://example.com',
             authorizationEndpoint: 'https://example.com/auth',
             tokenEndpoint: 'https://example.com/token',
             userinfoEndpoint: 'https://example.com/userinfo',
             jwksUri: 'https://example.com/jwks',
             pushedAuthorizationRequestEndpoint: 'https://example.com/par',
-        ));
+        ))->toArray());
+    }
+
+    /**
+     * Every other test in this file seeds the cache by hand, so none of them would
+     * notice if the discovery service started writing a shape the reader rejects.
+     * This one goes through the real writer.
+     */
+    public function test_get_jwks_reads_what_the_discovery_service_actually_wrote(): void
+    {
+        Cache::forget('openId');
+
+        $mockDiscovery = (string) json_encode([
+            'issuer' => 'https://example.com',
+            'authorization_endpoint' => 'https://example.com/auth',
+            'token_endpoint' => 'https://example.com/token',
+            'userinfo_endpoint' => 'https://example.com/userinfo',
+            'jwks_uri' => 'https://example.com/jwks',
+            'pushed_authorization_request_endpoint' => 'https://example.com/par',
+        ]);
+
+        $mockJwks = (string) json_encode([
+            'keys' => [
+                [
+                    'kty' => 'RSA',
+                    'kid' => '1b94c',
+                    'use' => 'sig',
+                    'n' => '...',
+                    'e' => 'AQAB',
+                ],
+            ],
+        ]);
+
+        Http::fake([
+            'https://example.com/discovery' => Http::response($mockDiscovery, 200),
+            'https://example.com/jwks' => Http::response($mockJwks, 200),
+        ]);
+
+        (new OpenIdDiscoveryService)->cacheOpenIdDiscovery('https://example.com/discovery', 'openId');
+
+        $this->assertInstanceOf(JWKSet::class, (new JwksService)->getJwks('openId'));
     }
 
     public function test_get_jwks_success(): void

--- a/tests/Unit/Services/OpenIdDiscoveryServiceTest.php
+++ b/tests/Unit/Services/OpenIdDiscoveryServiceTest.php
@@ -32,13 +32,128 @@ class OpenIdDiscoveryServiceTest extends TestCase
 
         $cached = Cache::get('openId:singpass');
 
-        $this->assertInstanceOf(OpenIdConfigurationDto::class, $cached);
-        $this->assertEquals('https://example.com', $cached->issuer);
-        $this->assertEquals('https://example.com/auth', $cached->authorizationEndpoint);
-        $this->assertEquals('https://example.com/token', $cached->tokenEndpoint);
-        $this->assertEquals('https://example.com/userinfo', $cached->userinfoEndpoint);
-        $this->assertEquals('https://example.com/jwks', $cached->jwksUri);
-        $this->assertEquals('https://example.com/par', $cached->pushedAuthorizationRequestEndpoint);
+        $config = OpenIdConfigurationDto::fromCache($cached);
+
+        $this->assertInstanceOf(OpenIdConfigurationDto::class, $config);
+        $this->assertEquals('https://example.com', $config->issuer);
+        $this->assertEquals('https://example.com/auth', $config->authorizationEndpoint);
+        $this->assertEquals('https://example.com/token', $config->tokenEndpoint);
+        $this->assertEquals('https://example.com/userinfo', $config->userinfoEndpoint);
+        $this->assertEquals('https://example.com/jwks', $config->jwksUri);
+        $this->assertEquals('https://example.com/par', $config->pushedAuthorizationRequestEndpoint);
+    }
+
+    public function test_cache_open_id_discovery_stores_a_plain_array(): void
+    {
+        $mockResponse = (string) json_encode([
+            'issuer' => 'https://example.com',
+            'authorization_endpoint' => 'https://example.com/auth',
+            'token_endpoint' => 'https://example.com/token',
+            'userinfo_endpoint' => 'https://example.com/userinfo',
+            'jwks_uri' => 'https://example.com/jwks',
+            'pushed_authorization_request_endpoint' => 'https://example.com/par',
+        ]);
+
+        Http::fake([
+            'https://example.com/discovery' => Http::response($mockResponse, 200),
+        ]);
+
+        (new OpenIdDiscoveryService)->cacheOpenIdDiscovery('https://example.com/discovery', 'openId:plain-array-test');
+
+        $cached = Cache::get('openId:plain-array-test');
+
+        $this->assertIsArray($cached);
+
+        // Round-tripping through JSON unchanged proves there is no object anywhere in the
+        // payload, whatever the cache driver happens to do with serialisation.
+        $this->assertSame($cached, json_decode((string) json_encode($cached), true));
+
+        $this->assertSame('https://example.com', $cached['issuer']);
+        $this->assertSame('https://example.com/auth', $cached['authorization_endpoint']);
+        $this->assertSame('https://example.com/token', $cached['token_endpoint']);
+        $this->assertSame('https://example.com/userinfo', $cached['userinfo_endpoint']);
+        $this->assertSame('https://example.com/jwks', $cached['jwks_uri']);
+        $this->assertSame('https://example.com/par', $cached['pushed_authorization_request_endpoint']);
+    }
+
+    /**
+     * The v4 → v5 upgrade scenario: production caches still hold the DTO object
+     * that v4 serialized. Cache::remember alone would keep returning it until the
+     * TTL expired, failing every read in the meantime; the writer must discard it
+     * and re-run discovery instead. (An entry rejected by a Laravel 13
+     * cache.serializable_classes allowlist deserializes to __PHP_Incomplete_Class
+     * and takes the same not-an-array path.)
+     */
+    public function test_cache_open_id_discovery_replaces_a_stale_serialized_dto_entry(): void
+    {
+        Cache::put('openId:stale-dto', new OpenIdConfigurationDto(
+            issuer: 'https://stale.example.com',
+            authorizationEndpoint: 'https://stale.example.com/auth',
+            tokenEndpoint: 'https://stale.example.com/token',
+            userinfoEndpoint: 'https://stale.example.com/userinfo',
+            jwksUri: 'https://stale.example.com/jwks',
+            pushedAuthorizationRequestEndpoint: 'https://stale.example.com/par',
+        ));
+
+        Http::fake([
+            'https://example.com/discovery' => Http::response($this->validDiscoveryResponse(), 200),
+        ]);
+
+        (new OpenIdDiscoveryService)->cacheOpenIdDiscovery('https://example.com/discovery', 'openId:stale-dto');
+
+        $cached = Cache::get('openId:stale-dto');
+
+        $this->assertIsArray($cached);
+        $this->assertSame('https://example.com', $cached['issuer']);
+    }
+
+    public function test_cache_open_id_discovery_replaces_a_malformed_array_entry(): void
+    {
+        Cache::put('openId:malformed', ['issuer' => 'https://stale.example.com']);
+
+        Http::fake([
+            'https://example.com/discovery' => Http::response($this->validDiscoveryResponse(), 200),
+        ]);
+
+        (new OpenIdDiscoveryService)->cacheOpenIdDiscovery('https://example.com/discovery', 'openId:malformed');
+
+        $cached = Cache::get('openId:malformed');
+
+        $this->assertIsArray($cached);
+        $this->assertSame('https://example.com/jwks', $cached['jwks_uri']);
+    }
+
+    public function test_cache_open_id_discovery_keeps_a_valid_cached_entry(): void
+    {
+        $existing = (new OpenIdConfigurationDto(
+            issuer: 'https://cached.example.com',
+            authorizationEndpoint: 'https://cached.example.com/auth',
+            tokenEndpoint: 'https://cached.example.com/token',
+            userinfoEndpoint: 'https://cached.example.com/userinfo',
+            jwksUri: 'https://cached.example.com/jwks',
+            pushedAuthorizationRequestEndpoint: 'https://cached.example.com/par',
+        ))->toArray();
+
+        Cache::put('openId:valid', $existing);
+
+        Http::fake();
+
+        (new OpenIdDiscoveryService)->cacheOpenIdDiscovery('https://example.com/discovery', 'openId:valid');
+
+        Http::assertNothingSent();
+        $this->assertSame($existing, Cache::get('openId:valid'));
+    }
+
+    private function validDiscoveryResponse(): string
+    {
+        return (string) json_encode([
+            'issuer' => 'https://example.com',
+            'authorization_endpoint' => 'https://example.com/auth',
+            'token_endpoint' => 'https://example.com/token',
+            'userinfo_endpoint' => 'https://example.com/userinfo',
+            'jwks_uri' => 'https://example.com/jwks',
+            'pushed_authorization_request_endpoint' => 'https://example.com/par',
+        ]);
     }
 
     public function test_cache_open_id_discovery_missing_required_fields(): void

--- a/tests/Unit/Services/OpenIdDiscoveryServiceTest.php
+++ b/tests/Unit/Services/OpenIdDiscoveryServiceTest.php
@@ -77,8 +77,8 @@ class OpenIdDiscoveryServiceTest extends TestCase
     }
 
     /**
-     * The v4 → v5 upgrade scenario: production caches still hold the DTO object
-     * that v4 serialized. Cache::remember alone would keep returning it until the
+     * The v3 → v4 upgrade scenario: production caches still hold the DTO object
+     * that v3 serialized. Cache::remember alone would keep returning it until the
      * TTL expired, failing every read in the meantime; the writer must discard it
      * and re-run discovery instead. (An entry rejected by a Laravel 13
      * cache.serializable_classes allowlist deserializes to __PHP_Incomplete_Class

--- a/tests/Unit/Services/PushedAuthorizationRequestServiceTest.php
+++ b/tests/Unit/Services/PushedAuthorizationRequestServiceTest.php
@@ -21,14 +21,14 @@ class PushedAuthorizationRequestServiceTest extends TestCase
 
         $this->service = new PushedAuthorizationRequestService;
 
-        Cache::put('openId:test', new OpenIdConfigurationDto(
+        Cache::put('openId:test', (new OpenIdConfigurationDto(
             issuer: 'https://example.com',
             authorizationEndpoint: 'https://example.com/auth',
             tokenEndpoint: 'https://example.com/token',
             userinfoEndpoint: 'https://example.com/userinfo',
             jwksUri: 'https://example.com/jwks',
             pushedAuthorizationRequestEndpoint: 'https://example.com/fapi/par',
-        ));
+        ))->toArray());
     }
 
     public function test_send_request_success(): void

--- a/tests/Unit/Services/TokenExchangeServiceTest.php
+++ b/tests/Unit/Services/TokenExchangeServiceTest.php
@@ -36,14 +36,14 @@ class TokenExchangeServiceTest extends TestCase
         $this->dpopServiceMock->shouldReceive('generateProofJwt')
             ->andReturn('mock-dpop-proof-jwt');
 
-        Cache::put('openId', new OpenIdConfigurationDto(
+        Cache::put('openId', (new OpenIdConfigurationDto(
             issuer: 'https://example.com',
             authorizationEndpoint: 'https://example.com/auth',
             tokenEndpoint: 'https://example.com/token',
             userinfoEndpoint: 'https://example.com/userinfo',
             jwksUri: 'https://example.com/jwks',
             pushedAuthorizationRequestEndpoint: 'https://example.com/par',
-        ));
+        ))->toArray());
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
> [!NOTE]
> Stacked on #161 — base is `chore/drop-laravel-10-add-ci-matrix`, so this diff shows only the cache refactor. GitHub will retarget it to `master` automatically once #161 merges and its branch is deleted.

## Proposed changes

- Cache the OpenID discovery configuration as a plain array instead of a serialized `OpenIdConfigurationDto`, as groundwork for Laravel 13's [`cache.serializable_classes` configuration](https://laravel.com/docs/13.x/upgrade#cache-serializable_classes-configuration) — consuming apps never need to allowlist the package's DTO. Laravel 13 support itself is **not** part of this PR; it follows separately.
- Reads rehydrate through the new `OpenIdConfigurationDto::fromCache()`, reusing the discovery response validation and returning `null` for anything unusable.
- The discovery writer self-heals: an unusable cached entry — every earlier release stored an object (v3.x a serialized `OpenIdConfigurationDto`, v2.x the raw `stdClass` from `json_decode`), and an entry rejected by a `serializable_classes` allowlist deserializes to `__PHP_Incomplete_Class` — any of these is discarded and re-fetched instead of being kept until its TTL expires.

#### Link to Jira Ticket

NA

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Unit/Feature tests passed and maintained at 80% coverage
- [x] Label either `New feature`, `Bugfix`, `Breaking change`, `Refactoring`, `DevOps`, or `Documentation` on GitHub
- [x] I have reviewed the changes myself
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)

## Further comments

The cache payload shape is a behavioural change for anyone reading the OpenID cache key directly: the payload is now an array whose keys match the discovery response, not a DTO instance — covered in the CHANGELOG upgrade notes. New tests cover the stale serialized-DTO entry (upgrading to this release from any earlier one, all of which cached an object), a malformed array entry, and that a valid cached entry still short-circuits without an HTTP call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
