### PR TITLE
[DSO-3264] Exempt internal workflows from Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 5
+      exclude:
+        - "Accredifysg/Accredify-Github-Workflows*"
     groups:
       accredify-shared-workflows:
         patterns:


### PR DESCRIPTION
## Proposed changes

Exempt first-party internal dependencies from the Dependabot cooldown so they update immediately instead of waiting out the cooldown period, since they're implicitly trusted.

### Updated
- `.github/dependabot.yml`: added `cooldown.exclude` with `"Accredifysg/Accredify-Github-Workflows*"` to the `github-actions` block, mirroring its existing `groups.accredify-shared-workflows.patterns` entry character-for-character. `default-days: 5` preserved unchanged.

No `terraform` block exists in this repo (no `*.tf` files present), so no terraform changes were made. `composer` block cooldown left untouched.

#### Link to Jira Ticket
https://accredify.atlassian.net/browse/DSO-3264 <!-- Replace with actual JIRA ticket URL -->

## Checklist

- [ ] Unit/Feature tests passed and maintained at 80% coverage
- [ ] Label either `New feature`, `Bugfix`, `Breaking change`, `Refactoring`, `DevOps`, or `Documentation` on GitHub
- [ ] I have reviewed the changes myself
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have added/updated necessary documentation (if appropriate)

## Further comments

Config-only change; no functional code affected.
